### PR TITLE
[mainPage/myPage] 기본 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/chzzk/grassdiary/config/SwaggerConfig.java
+++ b/src/main/java/chzzk/grassdiary/config/SwaggerConfig.java
@@ -1,0 +1,12 @@
+package chzzk.grassdiary.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springframework.context.annotation.Configuration;
+@OpenAPIDefinition(
+        info = @Info(title = "GrassDiary API 명세서",
+                description = "사용자 어플 서비스 API 명세서",
+                version = "v1"))
+@Configuration
+public class SwaggerConfig {
+}

--- a/src/main/java/chzzk/grassdiary/config/SwaggerConfig.java
+++ b/src/main/java/chzzk/grassdiary/config/SwaggerConfig.java
@@ -3,6 +3,7 @@ package chzzk.grassdiary.config;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import org.springframework.context.annotation.Configuration;
+
 @OpenAPIDefinition(
         info = @Info(title = "GrassDiary API 명세서",
                 description = "사용자 어플 서비스 API 명세서",

--- a/src/main/java/chzzk/grassdiary/domain/base/BaseCreatedTimeEntity.java
+++ b/src/main/java/chzzk/grassdiary/domain/base/BaseCreatedTimeEntity.java
@@ -2,12 +2,11 @@ package chzzk.grassdiary.domain.base;
 
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDateTime;
 
 @Getter
 @Setter

--- a/src/main/java/chzzk/grassdiary/domain/base/BaseCreatedTimeEntity.java
+++ b/src/main/java/chzzk/grassdiary/domain/base/BaseCreatedTimeEntity.java
@@ -3,12 +3,14 @@ package chzzk.grassdiary.domain.base;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public class BaseCreatedTimeEntity {

--- a/src/main/java/chzzk/grassdiary/domain/base/BaseTimeEntity.java
+++ b/src/main/java/chzzk/grassdiary/domain/base/BaseTimeEntity.java
@@ -2,16 +2,15 @@ package chzzk.grassdiary.domain.base;
 
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
-
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public class BaseTimeEntity extends BaseCreatedTimeEntity{
+public class BaseTimeEntity extends BaseCreatedTimeEntity {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/chzzk/grassdiary/domain/color/ColorCode.java
+++ b/src/main/java/chzzk/grassdiary/domain/color/ColorCode.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -22,4 +23,10 @@ public class ColorCode {
     private String colorName;
 
     private String rgb;
+
+    @Builder
+    public ColorCode(String colorName, String rgb) {
+        this.colorName = colorName;
+        this.rgb = rgb;
+    }
 }

--- a/src/main/java/chzzk/grassdiary/domain/diary/Diary.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/Diary.java
@@ -13,8 +13,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+
 import java.util.ArrayList;
 import java.util.List;
+
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -51,4 +54,12 @@ public class Diary extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     private ConditionLevel conditionLevel;
+
+    @Builder
+    protected Diary(Member member, String content, Boolean hasTag, ConditionLevel conditionLevel) {
+        this.member = member;
+        this.content = content;
+        this.hasTag = hasTag;
+        this.conditionLevel = conditionLevel;
+    }
 }

--- a/src/main/java/chzzk/grassdiary/domain/diary/Diary.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/Diary.java
@@ -13,11 +13,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/chzzk/grassdiary/domain/diary/Diary.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/Diary.java
@@ -14,6 +14,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -61,5 +62,6 @@ public class Diary extends BaseTimeEntity {
         this.content = content;
         this.hasTag = hasTag;
         this.conditionLevel = conditionLevel;
+        this.setCreatedAt(LocalDateTime.now());
     }
 }

--- a/src/main/java/chzzk/grassdiary/domain/diary/DiaryRepository.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/DiaryRepository.java
@@ -2,5 +2,9 @@ package chzzk.grassdiary.domain.diary;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
+
+    List<Diary> findDiaryByIdOrderByCreatedAtDesc(Long memberId);
 }

--- a/src/main/java/chzzk/grassdiary/domain/diary/DiaryRepository.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/DiaryRepository.java
@@ -11,7 +11,7 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     @Query("SELECT d FROM Diary d WHERE d.member.id = :memberId AND " +
             "d.createdAt >= :startOfDay AND d.createdAt <= :endOfDay")
-    Diary findByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime startOfDay, LocalDateTime endOfDay);
+    List<Diary> findByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime startOfDay, LocalDateTime endOfDay);
 
     List<Diary> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/chzzk/grassdiary/domain/diary/DiaryRepository.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/DiaryRepository.java
@@ -1,5 +1,7 @@
 package chzzk.grassdiary.domain.diary;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -7,6 +9,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
+    Page<Diary> findDiaryByMemberId(Long memberId, Pageable pageable);
+
     List<Diary> findDiaryByIdOrderByCreatedAtDesc(Long memberId);
 
     @Query("SELECT d FROM Diary d WHERE d.member.id = :memberId AND " +

--- a/src/main/java/chzzk/grassdiary/domain/diary/DiaryRepository.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/DiaryRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
     Page<Diary> findDiaryByMemberId(Long memberId, Pageable pageable);
 
-    List<Diary> findDiaryByIdOrderByCreatedAtDesc(Long memberId);
+    List<Diary> findAllByMemberIdOrderByCreatedAt(Long memberId);
 
     @Query("SELECT d FROM Diary d WHERE d.member.id = :memberId AND " +
             "d.createdAt >= :startOfDay AND d.createdAt <= :endOfDay")

--- a/src/main/java/chzzk/grassdiary/domain/diary/DiaryRepository.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/DiaryRepository.java
@@ -12,4 +12,6 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
     @Query("SELECT d FROM Diary d WHERE d.member.id = :memberId AND " +
             "d.createdAt >= :startOfDay AND d.createdAt <= :endOfDay")
     Diary findByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime startOfDay, LocalDateTime endOfDay);
+
+    List<Diary> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/chzzk/grassdiary/domain/diary/DiaryRepository.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/DiaryRepository.java
@@ -1,10 +1,15 @@
 package chzzk.grassdiary.domain.diary;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
-
     List<Diary> findDiaryByIdOrderByCreatedAtDesc(Long memberId);
+
+    @Query("SELECT d FROM Diary d WHERE d.member.id = :memberId AND " +
+            "d.createdAt >= :startOfDay AND d.createdAt <= :endOfDay")
+    Diary findByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime startOfDay, LocalDateTime endOfDay);
 }

--- a/src/main/java/chzzk/grassdiary/domain/diary/DiaryRepository.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/DiaryRepository.java
@@ -1,12 +1,11 @@
 package chzzk.grassdiary.domain.diary;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-
-import java.time.LocalDateTime;
-import java.util.List;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
     Page<Diary> findDiaryByMemberId(Long memberId, Pageable pageable);
@@ -19,6 +18,7 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     List<Diary> findAllByMemberId(Long memberId);
 
-    List<Diary> findTop10ByIsPrivateFalseAndCreatedAtBetweenOrderByDiaryLikesDesc(LocalDateTime startOfDay, LocalDateTime endOfDay);
+    List<Diary> findTop10ByIsPrivateFalseAndCreatedAtBetweenOrderByDiaryLikesDesc(LocalDateTime startOfDay,
+                                                                                  LocalDateTime endOfDay);
 
 }

--- a/src/main/java/chzzk/grassdiary/domain/diary/DiaryRepository.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/DiaryRepository.java
@@ -14,4 +14,7 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
     List<Diary> findByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime startOfDay, LocalDateTime endOfDay);
 
     List<Diary> findAllByMemberId(Long memberId);
+
+    List<Diary> findTop10ByIsPrivateFalseAndCreatedAtBetweenOrderByDiaryLikesDesc(LocalDateTime startOfDay, LocalDateTime endOfDay);
+
 }

--- a/src/main/java/chzzk/grassdiary/domain/diary/tag/DiaryTagRepository.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/tag/DiaryTagRepository.java
@@ -1,9 +1,17 @@
 package chzzk.grassdiary.domain.diary.tag;
 
+import chzzk.grassdiary.domain.diary.Diary;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface DiaryTagRepository extends JpaRepository<DiaryTag, Long> {
-    List<DiaryTag> findByDiaryId(Long diaryId);
+    @Query("SELECT dt.diary FROM DiaryTag dt " +
+            "WHERE dt.memberTags.member.id = :memberId AND dt.memberTags.tagList.id = :tagId " +
+            "ORDER BY dt.diary.createdAt DESC")
+    List<Diary> findByMemberIdAndTagId(Long memberId, Long tagId);
+
+    @Query("SELECT dt.memberTags FROM DiaryTag dt WHERE dt.diary.id = :diaryId")
+    List<MemberTags> findMemberTagsByDiaryId(Long diaryId);
 }

--- a/src/main/java/chzzk/grassdiary/domain/diary/tag/DiaryTagRepository.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/tag/DiaryTagRepository.java
@@ -1,10 +1,9 @@
 package chzzk.grassdiary.domain.diary.tag;
 
 import chzzk.grassdiary.domain.diary.Diary;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-
-import java.util.List;
 
 public interface DiaryTagRepository extends JpaRepository<DiaryTag, Long> {
     @Query("SELECT dt.diary FROM DiaryTag dt " +

--- a/src/main/java/chzzk/grassdiary/domain/diary/tag/DiaryTagRepository.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/tag/DiaryTagRepository.java
@@ -2,5 +2,8 @@ package chzzk.grassdiary.domain.diary.tag;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface DiaryTagRepository extends JpaRepository<DiaryTag, Long> {
+    List<DiaryTag> findByDiaryId(Long diaryId);
 }

--- a/src/main/java/chzzk/grassdiary/domain/diary/tag/MemberTags.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/tag/MemberTags.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -27,4 +28,10 @@ public class MemberTags {
     @ManyToOne
     @JoinColumn(name = "tag_id")
     private TagList tagList;
+
+    @Builder
+    public MemberTags(Member member, TagList tagList) {
+        this.member = member;
+        this.tagList = tagList;
+    }
 }

--- a/src/main/java/chzzk/grassdiary/domain/diary/tag/MemberTagsRepository.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/tag/MemberTagsRepository.java
@@ -1,6 +1,11 @@
 package chzzk.grassdiary.domain.diary.tag;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface MemberTagsRepository extends JpaRepository<MemberTags, Long> {
+    @Query("SELECT mt.tagList.id FROM MemberTags mt WHERE mt.member.id = :memberId")
+    List<Long> findTagIdsByMemberId(Long memberId);
 }

--- a/src/main/java/chzzk/grassdiary/domain/diary/tag/MemberTagsRepository.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/tag/MemberTagsRepository.java
@@ -1,9 +1,8 @@
 package chzzk.grassdiary.domain.diary.tag;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-
-import java.util.List;
 
 public interface MemberTagsRepository extends JpaRepository<MemberTags, Long> {
     @Query("SELECT mt.tagList.id FROM MemberTags mt WHERE mt.member.id = :memberId")

--- a/src/main/java/chzzk/grassdiary/domain/diary/tag/TagList.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/tag/TagList.java
@@ -6,9 +6,18 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import java.util.ArrayList;
 import java.util.List;
 
+
+@Getter
+@Setter // DBTest에서 임시 사용
+@NoArgsConstructor
 @Entity
 public class TagList {
     @Id
@@ -21,5 +30,10 @@ public class TagList {
 
     @OneToMany(mappedBy = "tagList")
     private List<MemberTags> memberTags = new ArrayList<>();
+
+    @Builder
+    public TagList(String tag) {
+        this.tag = tag;
+    }
 }
 

--- a/src/main/java/chzzk/grassdiary/domain/diary/tag/TagList.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/tag/TagList.java
@@ -5,15 +5,10 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.util.ArrayList;
-import java.util.List;
-
 
 @Getter
 @Setter // DBTest에서 임시 사용
@@ -27,9 +22,6 @@ public class TagList {
 
     @Column(nullable = false)
     private String tag;
-
-    @OneToMany(mappedBy = "tagList")
-    private List<MemberTags> memberTags = new ArrayList<>();
 
     @Builder
     public TagList(String tag) {

--- a/src/main/java/chzzk/grassdiary/domain/diary/tag/TagListRepository.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/tag/TagListRepository.java
@@ -2,5 +2,8 @@ package chzzk.grassdiary.domain.diary.tag;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TagListRepository extends JpaRepository<TagList, Long> {
+    List<TagList> findTagDTOByIdIn(List<Long> ids);
 }

--- a/src/main/java/chzzk/grassdiary/domain/diary/tag/TagListRepository.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/tag/TagListRepository.java
@@ -1,8 +1,7 @@
 package chzzk.grassdiary.domain.diary.tag;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TagListRepository extends JpaRepository<TagList, Long> {
     List<TagList> findTagDTOByIdIn(List<Long> ids);

--- a/src/main/java/chzzk/grassdiary/domain/member/Member.java
+++ b/src/main/java/chzzk/grassdiary/domain/member/Member.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -43,4 +44,10 @@ public class Member extends BaseTimeEntity {
     private ColorCode currentColorCode;
 
     private String profileIntro;
+
+    @Builder
+    public Member(String nickname, String email) {
+        this.nickname = nickname;
+        this.email = email;
+    }
 }

--- a/src/main/java/chzzk/grassdiary/domain/member/Member.java
+++ b/src/main/java/chzzk/grassdiary/domain/member/Member.java
@@ -35,6 +35,7 @@ public class Member extends BaseTimeEntity {
 
     private Long grassCount;
 
+    @ColumnDefault("0")
     private Integer rewardPoint;
 
     @ColumnDefault("false")
@@ -50,5 +51,6 @@ public class Member extends BaseTimeEntity {
         this.nickname = nickname;
         this.email = email;
         this.currentColorCode = currentColorCode;
+        this.rewardPoint = 0;
     }
 }

--- a/src/main/java/chzzk/grassdiary/domain/member/Member.java
+++ b/src/main/java/chzzk/grassdiary/domain/member/Member.java
@@ -46,8 +46,9 @@ public class Member extends BaseTimeEntity {
     private String profileIntro;
 
     @Builder
-    public Member(String nickname, String email) {
+    public Member(String nickname, String email, ColorCode currentColorCode) {
         this.nickname = nickname;
         this.email = email;
+        this.currentColorCode = currentColorCode;
     }
 }

--- a/src/main/java/chzzk/grassdiary/domain/member/MemberRepository.java
+++ b/src/main/java/chzzk/grassdiary/domain/member/MemberRepository.java
@@ -1,6 +1,9 @@
 package chzzk.grassdiary.domain.member;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    @Query("SELECT m.rewardPoint FROM Member m WHERE m.id = :memberId")
+    Integer findRewardPointById(Long memberId);
 }

--- a/src/main/java/chzzk/grassdiary/service/DiaryService.java
+++ b/src/main/java/chzzk/grassdiary/service/DiaryService.java
@@ -12,18 +12,17 @@ import chzzk.grassdiary.web.dto.diary.CountAndMonthGrassDTO;
 import chzzk.grassdiary.web.dto.diary.DiaryDTO;
 import chzzk.grassdiary.web.dto.diary.PopularDiaryDTO;
 import chzzk.grassdiary.web.dto.member.GrassInfoDTO;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -35,7 +34,7 @@ public class DiaryService {
     @Transactional(readOnly = true)
     public Page<DiaryDTO> findAll(Pageable pageable, Long memberId) {
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 멤버 입니다. (id: " + memberId + ")"));
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 멤버 입니다. (id: " + memberId + ")"));
 
         return diaryRepository.findDiaryByMemberId(memberId, pageable)
                 .map(diary -> {
@@ -82,22 +81,23 @@ public class DiaryService {
     }
 
     /**
-     * 유저의 총 잔디 개수(count)
-     * 유저의 이번 달 잔디 정보(grassInfoDTO<grassList, colorRGB>)
+     * 유저의 총 잔디 개수(count) 유저의 이번 달 잔디 정보(grassInfoDTO<grassList>, colorRGB>)
      */
     @Transactional(readOnly = true)
     public CountAndMonthGrassDTO countAllAndMonthGrass(Long memberId) {
         List<Diary> allByMemberId = diaryRepository.findAllByMemberId(memberId);
 
         LocalDate startOfMonth = LocalDate.of(LocalDate.now().getYear(), LocalDate.now().getMonth(), 1);
-        LocalDate today = LocalDate.of(LocalDate.now().getYear(), LocalDate.now().getMonth(), LocalDate.now().getDayOfMonth());
+        LocalDate today = LocalDate.of(LocalDate.now().getYear(), LocalDate.now().getMonth(),
+                LocalDate.now().getDayOfMonth());
         LocalDateTime startOfDay = startOfMonth.atStartOfDay();
         LocalDateTime endOfToday = today.atTime(LocalTime.MAX);
 
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 멤버 입니다. (id: " + memberId + ")"));
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 멤버 입니다. (id: " + memberId + ")"));
 
-        List<Diary> thisMonthHistory = diaryRepository.findByMemberIdAndCreatedAtBetween(memberId, startOfDay, endOfToday);
+        List<Diary> thisMonthHistory = diaryRepository.findByMemberIdAndCreatedAtBetween(memberId, startOfDay,
+                endOfToday);
         ColorCode colorCode = member.getCurrentColorCode();
 
         return new CountAndMonthGrassDTO(
@@ -111,10 +111,12 @@ public class DiaryService {
      */
     @Transactional(readOnly = true)
     public List<PopularDiaryDTO> popularDiary(Long memberId) {
-        LocalDate today = LocalDate.of(LocalDate.now().getYear(), LocalDate.now().getMonth(), LocalDate.now().getDayOfMonth());
+        LocalDate today = LocalDate.of(LocalDate.now().getYear(), LocalDate.now().getMonth(),
+                LocalDate.now().getDayOfMonth());
 
         List<Diary> popularDiaries = diaryRepository
-                .findTop10ByIsPrivateFalseAndCreatedAtBetweenOrderByDiaryLikesDesc(today.atStartOfDay(), today.atTime(LocalTime.MAX));
+                .findTop10ByIsPrivateFalseAndCreatedAtBetweenOrderByDiaryLikesDesc(today.atStartOfDay(),
+                        today.atTime(LocalTime.MAX));
 
         if (popularDiaries.isEmpty()) {
             // TODO: 오늘의 일기 없음

--- a/src/main/java/chzzk/grassdiary/service/DiaryService.java
+++ b/src/main/java/chzzk/grassdiary/service/DiaryService.java
@@ -1,0 +1,56 @@
+package chzzk.grassdiary.service;
+
+import chzzk.grassdiary.domain.diary.Diary;
+import chzzk.grassdiary.domain.diary.DiaryRepository;
+import chzzk.grassdiary.domain.diary.tag.DiaryTagRepository;
+import chzzk.grassdiary.domain.diary.tag.MemberTags;
+import chzzk.grassdiary.domain.diary.tag.DiaryTag;
+import chzzk.grassdiary.web.dto.diary.DiaryDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class DiaryService {
+    private final DiaryRepository diaryRepository;
+    private final DiaryTagRepository diaryTagRepository;
+
+    public DiaryDTO findByDate(Long id, String date) {
+
+        LocalDate localDate = LocalDate.parse(date);
+
+        LocalDateTime startOfDay = localDate.atStartOfDay();
+        LocalDateTime endOfDay = localDate.atTime(LocalTime.MAX);
+
+        Diary diary = diaryRepository.findByMemberIdAndCreatedAtBetween(id, startOfDay, endOfDay);
+        if (diary == null) {
+            // TODO: 일기를 찾지 못한 경우 보내는 값 설정 해야함
+            return null;
+        }
+
+        System.out.println(diary.getContent());
+
+        // 해시태그 리스트 가져오기
+        List<MemberTags> tags = diaryTagRepository.findByDiaryId(diary.getId())
+                .stream()
+                .map(DiaryTag::getMemberTags)
+                .collect(Collectors.toList());
+
+        return new DiaryDTO(
+                diary.getId(),
+                diary.getContent(),
+                tags,
+                diary.getConditionLevel().getTransparency(),
+                diary.getIsPrivate(),
+                diary.getDiaryLikes().size(),
+                diary.getCreatedAt().format(DateTimeFormatter.ofPattern("yy년 MM월 dd일")),
+                diary.getCreatedAt().format(DateTimeFormatter.ofPattern("HH:mm")));
+    }
+}

--- a/src/main/java/chzzk/grassdiary/service/DiaryService.java
+++ b/src/main/java/chzzk/grassdiary/service/DiaryService.java
@@ -5,7 +5,7 @@ import chzzk.grassdiary.domain.diary.Diary;
 import chzzk.grassdiary.domain.diary.DiaryRepository;
 import chzzk.grassdiary.domain.diary.tag.DiaryTagRepository;
 import chzzk.grassdiary.domain.diary.tag.MemberTags;
-import chzzk.grassdiary.domain.diary.tag.DiaryTag;
+import chzzk.grassdiary.domain.diary.tag.TagList;
 import chzzk.grassdiary.domain.member.Member;
 import chzzk.grassdiary.domain.member.MemberRepository;
 import chzzk.grassdiary.web.dto.diary.CountAndMonthGrassDTO;
@@ -48,10 +48,10 @@ public class DiaryService {
         System.out.println(diary.getContent());
 
         // 해시태그 리스트 가져오기
-        List<MemberTags> tags = diaryTagRepository.findByDiaryId(diary.getId())
-                .stream()
-                .map(DiaryTag::getMemberTags)
-                .collect(Collectors.toList());
+        List<MemberTags> diaryTags = diaryTagRepository.findMemberTagsByDiaryId(diary.getId());
+        List<TagList> tags = diaryTags.stream()
+                .map(MemberTags::getTagList)
+                .toList();
 
         return new DiaryDTO(
                 diary.getId(),

--- a/src/main/java/chzzk/grassdiary/service/DiaryService.java
+++ b/src/main/java/chzzk/grassdiary/service/DiaryService.java
@@ -5,6 +5,7 @@ import chzzk.grassdiary.domain.diary.DiaryRepository;
 import chzzk.grassdiary.domain.diary.tag.DiaryTagRepository;
 import chzzk.grassdiary.domain.diary.tag.MemberTags;
 import chzzk.grassdiary.domain.diary.tag.DiaryTag;
+import chzzk.grassdiary.web.dto.diary.CountDTO;
 import chzzk.grassdiary.web.dto.diary.DiaryDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -52,5 +53,10 @@ public class DiaryService {
                 diary.getDiaryLikes().size(),
                 diary.getCreatedAt().format(DateTimeFormatter.ofPattern("yy년 MM월 dd일")),
                 diary.getCreatedAt().format(DateTimeFormatter.ofPattern("HH:mm")));
+    }
+
+    public CountDTO countAll(Long memberId) {
+        List<Diary> allByMemberId = diaryRepository.findAllByMemberId(memberId);
+        return new CountDTO(allByMemberId.size());
     }
 }

--- a/src/main/java/chzzk/grassdiary/service/MainService.java
+++ b/src/main/java/chzzk/grassdiary/service/MainService.java
@@ -1,0 +1,23 @@
+package chzzk.grassdiary.service;
+
+import chzzk.grassdiary.web.dto.main.TodayInfoDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@RequiredArgsConstructor
+@Service
+public class MainService {
+
+    public TodayInfoDTO getTodayInfo() {
+        LocalDate today = LocalDate.now();
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("오늘은 M월 d일입니다.");
+        String todayDate = today.format(dateTimeFormatter);
+
+        String todayQuestion = "오늘의 질문";
+
+        return new TodayInfoDTO(todayDate, todayQuestion);
+    }
+}

--- a/src/main/java/chzzk/grassdiary/service/MainService.java
+++ b/src/main/java/chzzk/grassdiary/service/MainService.java
@@ -1,11 +1,10 @@
 package chzzk.grassdiary.service;
 
 import chzzk.grassdiary.web.dto.main.TodayInfoDTO;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/chzzk/grassdiary/service/MyPageService.java
+++ b/src/main/java/chzzk/grassdiary/service/MyPageService.java
@@ -1,26 +1,38 @@
 package chzzk.grassdiary.service;
 
+import chzzk.grassdiary.domain.color.ColorCode;
 import chzzk.grassdiary.domain.color.ColorCodeRepository;
+import chzzk.grassdiary.domain.diary.Diary;
 import chzzk.grassdiary.domain.diary.DiaryRepository;
 import chzzk.grassdiary.domain.member.Member;
 import chzzk.grassdiary.domain.member.MemberRepository;
+import chzzk.grassdiary.web.dto.member.GrassInfoDTO;
 import chzzk.grassdiary.web.dto.member.MemberInfoDTO;
-import chzzk.grassdiary.web.dto.mypage.GetProfileDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
 public class MyPageService {
     MemberRepository memberRepository;
     DiaryRepository diaryRepository;
-    ColorCodeRepository colorCodeRepository;
 
     @Transactional(readOnly = true)
     public MemberInfoDTO findProfileById(Long id) {
         Member member = memberRepository.findById(id)
             .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 멤버 입니다. (id: " + id + ")"));
         return new MemberInfoDTO(member.getProfileImageUrl(), member.getNickname(), member.getProfileIntro());
+    }
+
+    @Transactional(readOnly = true)
+    public GrassInfoDTO findGrassHistoryById(Long memberId) {
+        List<Diary> diaryHistory = diaryRepository.findDiaryByIdOrderByCreatedAtDesc(memberId);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 멤버 입니다. (id: " + memberId + ")"));
+        ColorCode colorCode = member.getCurrentColorCode();
+        return new GrassInfoDTO(diaryHistory, colorCode.getRgb());
     }
 }

--- a/src/main/java/chzzk/grassdiary/service/MyPageService.java
+++ b/src/main/java/chzzk/grassdiary/service/MyPageService.java
@@ -30,7 +30,7 @@ public class MyPageService {
 
     @Transactional(readOnly = true)
     public GrassInfoDTO findGrassHistoryById(Long memberId) {
-        List<Diary> diaryHistory = diaryRepository.findDiaryByIdOrderByCreatedAtDesc(memberId);
+        List<Diary> diaryHistory = diaryRepository.findAllByMemberIdOrderByCreatedAt(memberId);
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 멤버 입니다. (id: " + memberId + ")"));
         ColorCode colorCode = member.getCurrentColorCode();

--- a/src/main/java/chzzk/grassdiary/service/MyPageService.java
+++ b/src/main/java/chzzk/grassdiary/service/MyPageService.java
@@ -8,6 +8,7 @@ import chzzk.grassdiary.domain.member.Member;
 import chzzk.grassdiary.domain.member.MemberRepository;
 import chzzk.grassdiary.web.dto.member.GrassInfoDTO;
 import chzzk.grassdiary.web.dto.member.MemberInfoDTO;
+import chzzk.grassdiary.web.dto.member.TotalRewardDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,8 +18,8 @@ import java.util.List;
 @RequiredArgsConstructor
 @Service
 public class MyPageService {
-    MemberRepository memberRepository;
-    DiaryRepository diaryRepository;
+    private final MemberRepository memberRepository;
+    private final DiaryRepository diaryRepository;
 
     @Transactional(readOnly = true)
     public MemberInfoDTO findProfileById(Long id) {
@@ -34,5 +35,16 @@ public class MyPageService {
                 .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 멤버 입니다. (id: " + memberId + ")"));
         ColorCode colorCode = member.getCurrentColorCode();
         return new GrassInfoDTO(diaryHistory, colorCode.getRgb());
+    }
+
+    /**
+     * 사용자의 리워드 포인트 반환
+     */
+    public TotalRewardDTO findTotalRewardById(Long memberId) {
+        memberRepository.findById(memberId)
+                .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 멤버 입니다. (id: " + memberId + ")"));
+
+        Integer rewardPoint = memberRepository.findRewardPointById(memberId);
+        return new TotalRewardDTO(rewardPoint);
     }
 }

--- a/src/main/java/chzzk/grassdiary/service/MyPageService.java
+++ b/src/main/java/chzzk/grassdiary/service/MyPageService.java
@@ -1,0 +1,26 @@
+package chzzk.grassdiary.service;
+
+import chzzk.grassdiary.domain.color.ColorCodeRepository;
+import chzzk.grassdiary.domain.diary.DiaryRepository;
+import chzzk.grassdiary.domain.member.Member;
+import chzzk.grassdiary.domain.member.MemberRepository;
+import chzzk.grassdiary.web.dto.member.MemberInfoDTO;
+import chzzk.grassdiary.web.dto.mypage.GetProfileDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class MyPageService {
+    MemberRepository memberRepository;
+    DiaryRepository diaryRepository;
+    ColorCodeRepository colorCodeRepository;
+
+    @Transactional(readOnly = true)
+    public MemberInfoDTO findProfileById(Long id) {
+        Member member = memberRepository.findById(id)
+            .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 멤버 입니다. (id: " + id + ")"));
+        return new MemberInfoDTO(member.getProfileImageUrl(), member.getNickname(), member.getProfileIntro());
+    }
+}

--- a/src/main/java/chzzk/grassdiary/service/MyPageService.java
+++ b/src/main/java/chzzk/grassdiary/service/MyPageService.java
@@ -1,7 +1,6 @@
 package chzzk.grassdiary.service;
 
 import chzzk.grassdiary.domain.color.ColorCode;
-import chzzk.grassdiary.domain.color.ColorCodeRepository;
 import chzzk.grassdiary.domain.diary.Diary;
 import chzzk.grassdiary.domain.diary.DiaryRepository;
 import chzzk.grassdiary.domain.member.Member;
@@ -9,11 +8,10 @@ import chzzk.grassdiary.domain.member.MemberRepository;
 import chzzk.grassdiary.web.dto.member.GrassInfoDTO;
 import chzzk.grassdiary.web.dto.member.MemberInfoDTO;
 import chzzk.grassdiary.web.dto.member.TotalRewardDTO;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -24,7 +22,7 @@ public class MyPageService {
     @Transactional(readOnly = true)
     public MemberInfoDTO findProfileById(Long id) {
         Member member = memberRepository.findById(id)
-            .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 멤버 입니다. (id: " + id + ")"));
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 멤버 입니다. (id: " + id + ")"));
         return new MemberInfoDTO(member.getProfileImageUrl(), member.getNickname(), member.getProfileIntro());
     }
 
@@ -32,7 +30,7 @@ public class MyPageService {
     public GrassInfoDTO findGrassHistoryById(Long memberId) {
         List<Diary> diaryHistory = diaryRepository.findAllByMemberIdOrderByCreatedAt(memberId);
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 멤버 입니다. (id: " + memberId + ")"));
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 멤버 입니다. (id: " + memberId + ")"));
         ColorCode colorCode = member.getCurrentColorCode();
         return new GrassInfoDTO(diaryHistory, colorCode.getRgb());
     }
@@ -42,7 +40,7 @@ public class MyPageService {
      */
     public TotalRewardDTO findTotalRewardById(Long memberId) {
         memberRepository.findById(memberId)
-                .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 멤버 입니다. (id: " + memberId + ")"));
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 멤버 입니다. (id: " + memberId + ")"));
 
         Integer rewardPoint = memberRepository.findRewardPointById(memberId);
         return new TotalRewardDTO(rewardPoint);

--- a/src/main/java/chzzk/grassdiary/service/TagService.java
+++ b/src/main/java/chzzk/grassdiary/service/TagService.java
@@ -1,12 +1,19 @@
 package chzzk.grassdiary.service;
 
+import chzzk.grassdiary.domain.diary.Diary;
+import chzzk.grassdiary.domain.diary.tag.DiaryTagRepository;
+import chzzk.grassdiary.domain.diary.tag.MemberTags;
 import chzzk.grassdiary.domain.diary.tag.MemberTagsRepository;
+import chzzk.grassdiary.domain.diary.tag.TagList;
 import chzzk.grassdiary.domain.diary.tag.TagListRepository;
+import chzzk.grassdiary.web.dto.diary.DiaryDTO;
 import chzzk.grassdiary.web.dto.diary.TagDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -14,6 +21,7 @@ public class TagService {
 
     private final MemberTagsRepository memberTagsRepository;
     private final TagListRepository tagListRepository;
+    private final DiaryTagRepository diaryTagRepository;
 
     /**
      * 유저의 해시태그 리스트 반환
@@ -25,5 +33,35 @@ public class TagService {
         // 태그 DTO 조회
         return tagListRepository.findTagDTOByIdIn(tagIds).stream()
                 .map(tag -> new TagDTO(tag.getId(), tag.getTag())).toList();
+    }
+
+    /**
+     * 유저의 다이어리 태그로 다이어리 검색
+     */
+    public List<DiaryDTO> findByHashTagId(Long memberId, Long tagId) {
+        List<Diary> diaries = diaryTagRepository.findByMemberIdAndTagId(memberId, tagId);
+
+        return diaries.stream()
+                .map(diary -> {
+                    List<MemberTags> diaryTags = diaryTagRepository.findMemberTagsByDiaryId(diary.getId());
+                    List<TagList> tags = diaryTags.stream()
+                            .map(MemberTags::getTagList)
+                            .toList();
+                    return convertDiaryDTO(diary, tags);
+                })
+                .collect(Collectors.toList());
+    }
+
+    private DiaryDTO convertDiaryDTO(Diary diary, List<TagList> tags) {
+        return new DiaryDTO(
+                diary.getId(),
+                diary.getContent(),
+                tags,
+                diary.getConditionLevel().getTransparency(),
+                diary.getIsPrivate(),
+                diary.getDiaryLikes().size(),
+                diary.getCreatedAt().format(DateTimeFormatter.ofPattern("yy년 MM월 dd일")),
+                diary.getCreatedAt().format(DateTimeFormatter.ofPattern("HH:mm"))
+        );
     }
 }

--- a/src/main/java/chzzk/grassdiary/service/TagService.java
+++ b/src/main/java/chzzk/grassdiary/service/TagService.java
@@ -11,7 +11,6 @@ import chzzk.grassdiary.web.dto.diary.TagDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -47,21 +46,8 @@ public class TagService {
                     List<TagList> tags = diaryTags.stream()
                             .map(MemberTags::getTagList)
                             .toList();
-                    return convertDiaryDTO(diary, tags);
+                    return DiaryDTO.from(diary, tags);
                 })
                 .collect(Collectors.toList());
-    }
-
-    private DiaryDTO convertDiaryDTO(Diary diary, List<TagList> tags) {
-        return new DiaryDTO(
-                diary.getId(),
-                diary.getContent(),
-                tags,
-                diary.getConditionLevel().getTransparency(),
-                diary.getIsPrivate(),
-                diary.getDiaryLikes().size(),
-                diary.getCreatedAt().format(DateTimeFormatter.ofPattern("yy년 MM월 dd일")),
-                diary.getCreatedAt().format(DateTimeFormatter.ofPattern("HH:mm"))
-        );
     }
 }

--- a/src/main/java/chzzk/grassdiary/service/TagService.java
+++ b/src/main/java/chzzk/grassdiary/service/TagService.java
@@ -8,11 +8,10 @@ import chzzk.grassdiary.domain.diary.tag.TagList;
 import chzzk.grassdiary.domain.diary.tag.TagListRepository;
 import chzzk.grassdiary.web.dto.diary.DiaryDTO;
 import chzzk.grassdiary.web.dto.diary.TagDTO;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/chzzk/grassdiary/service/TagService.java
+++ b/src/main/java/chzzk/grassdiary/service/TagService.java
@@ -1,0 +1,29 @@
+package chzzk.grassdiary.service;
+
+import chzzk.grassdiary.domain.diary.tag.MemberTagsRepository;
+import chzzk.grassdiary.domain.diary.tag.TagListRepository;
+import chzzk.grassdiary.web.dto.diary.TagDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class TagService {
+
+    private final MemberTagsRepository memberTagsRepository;
+    private final TagListRepository tagListRepository;
+
+    /**
+     * 유저의 해시태그 리스트 반환
+     */
+    public List<TagDTO> getMemberTags(Long memberId) {
+        // 멤버가 사용한 태그의 tag_id 목록 가져오기
+        List<Long> tagIds = memberTagsRepository.findTagIdsByMemberId(memberId);
+
+        // 태그 DTO 조회
+        return tagListRepository.findTagDTOByIdIn(tagIds).stream()
+                .map(tag -> new TagDTO(tag.getId(), tag.getTag())).toList();
+    }
+}

--- a/src/main/java/chzzk/grassdiary/web/controller/DiaryController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/DiaryController.java
@@ -29,17 +29,15 @@ public class DiaryController {
     private final DiaryService diaryService;
 
     /**
-     * 유저별 일기장 메인 페이지
-     * 1) 디폴트 API(최신순 5개씩)
-     *  : api/diary/main/1?page=0
-     * 2) 오래된 순 5개씩
-     *  : api/diary/main/1?page=0&sort=createdAt,ASC
+     * 유저별 일기장 메인 페이지 1) 디폴트 API(최신순 5개씩) : api/diary/main/1?page=0 2) 오래된 순 5개씩 :
+     * api/diary/main/1?page=0&sort=createdAt,ASC
      */
     @GetMapping("/main/{memberId}")
     @Operation(
             summary = "유저별 일기장 메인 페이지",
-            description = "최신순 5개씩(`api/diary/main/{memberId}?page=0`), 오래된 순 5개씩(`api/diary/main/1?page=0&sort=createdAt,ASC`) " +
-                    "\n페이지를 나타내는 변수가 있는데, 해당 표에는 바로 나타나지 않으니 실행 시켜보시는 것을 추천드립니다.")
+            description =
+                    "최신순 5개씩(`api/diary/main/{memberId}?page=0`), 오래된 순 5개씩(`api/diary/main/1?page=0&sort=createdAt,ASC`) "
+                            + "\n페이지를 나타내는 변수가 있는데, 해당 표에는 바로 나타나지 않으니 실행 시켜보시는 것을 추천드립니다.")
     @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = DiaryDTO.class)))
     public ResponseEntity<?> findAll(
             @PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
@@ -48,10 +46,6 @@ public class DiaryController {
         return ResponseEntity.ok(diaryService.findAll(pageable, memberId));
     }
 
-    /**
-     * 유저별 날짜에 따른 일기 검색(잔디 클릭시 사용)
-     * API 형식: api/diary/1?date=2024-02-21
-     */
     @GetMapping("/{memberId}")
     @Operation(
             summary = "날짜별 일기 검색",
@@ -65,10 +59,6 @@ public class DiaryController {
         return ResponseEntity.ok(diaryService.findByDate(memberId, date));
     }
 
-    /**
-     * 대표 일기(오늘의 좋아요 가장 많은 받은 일기 10개)
-     * memberId: 해당 일기에 대한 작성자의 좋아요 유무를 판단하기 위해 필요
-     */
     @GetMapping("/popularity/{memberId}")
     @Operation(
             summary = "대표 일기",

--- a/src/main/java/chzzk/grassdiary/web/controller/DiaryController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/DiaryController.java
@@ -1,6 +1,15 @@
 package chzzk.grassdiary.web.controller;
 
 import chzzk.grassdiary.service.DiaryService;
+import chzzk.grassdiary.web.dto.diary.DiaryDTO;
+import chzzk.grassdiary.web.dto.diary.PopularDiaryDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -15,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/diary")
+@Tag(name = "일기 컨트롤러")
 public class DiaryController {
     private final DiaryService diaryService;
 
@@ -26,6 +36,11 @@ public class DiaryController {
      *  : api/diary/main/1?page=0&sort=createdAt,ASC
      */
     @GetMapping("/main/{memberId}")
+    @Operation(
+            summary = "유저별 일기장 메인 페이지",
+            description = "최신순 5개씩(`api/diary/main/{memberId}?page=0`), 오래된 순 5개씩(`api/diary/main/1?page=0&sort=createdAt,ASC`) " +
+                    "\n페이지를 나타내는 변수가 있는데, 해당 표에는 바로 나타나지 않으니 실행 시켜보시는 것을 추천드립니다.")
+    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = DiaryDTO.class)))
     public ResponseEntity<?> findAll(
             @PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             @PathVariable Long memberId
@@ -38,6 +53,14 @@ public class DiaryController {
      * API 형식: api/diary/1?date=2024-02-21
      */
     @GetMapping("/{memberId}")
+    @Operation(
+            summary = "날짜별 일기 검색",
+            description = "유저별 날짜에 따른 일기 검색(잔디 클릭시 사용)")
+    @Parameters({
+            @Parameter(name = "memberId", description = "멤버 아이디"),
+            @Parameter(name = "date", description = "검색하는 날짜 String 값(형식: yyyy-MM-dd)")
+    })
+    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = DiaryDTO.class)))
     public ResponseEntity<?> searchByDate(@PathVariable Long memberId, @RequestParam String date) {
         return ResponseEntity.ok(diaryService.findByDate(memberId, date));
     }
@@ -47,6 +70,11 @@ public class DiaryController {
      * memberId: 해당 일기에 대한 작성자의 좋아요 유무를 판단하기 위해 필요
      */
     @GetMapping("/popularity/{memberId}")
+    @Operation(
+            summary = "대표 일기",
+            description = "오늘의 좋아요 가장 많은 받은 일기 10개")
+    @Parameter(name = "memberId", description = "멤버 아이디(해당 일기에 대한 작성자의 좋아요 유무를 판단하기 위해 필요)")
+    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = PopularDiaryDTO.class)))
     public ResponseEntity<?> todayPopularDiary(@PathVariable Long memberId) {
         return ResponseEntity.ok(diaryService.popularDiary(memberId));
     }

--- a/src/main/java/chzzk/grassdiary/web/controller/DiaryController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/DiaryController.java
@@ -2,6 +2,9 @@ package chzzk.grassdiary.web.controller;
 
 import chzzk.grassdiary.service.DiaryService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -14,6 +17,21 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/diary")
 public class DiaryController {
     private final DiaryService diaryService;
+
+    /**
+     * 유저별 일기장 메인 페이지
+     * 1) 디폴트 API(최신순 5개씩)
+     *  : api/diary/main/1?page=0
+     * 2) 오래된 순 5개씩
+     *  : api/diary/main/1?page=0&sort=createdAt,ASC
+     */
+    @GetMapping("/main/{memberId}")
+    public ResponseEntity<?> findAll(
+            @PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @PathVariable Long memberId
+    ) {
+        return ResponseEntity.ok(diaryService.findAll(pageable, memberId));
+    }
 
     /**
      * 유저별 날짜에 따른 일기 검색(잔디 클릭시 사용)

--- a/src/main/java/chzzk/grassdiary/web/controller/DiaryController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/DiaryController.java
@@ -23,4 +23,13 @@ public class DiaryController {
     public ResponseEntity<?> searchByDate(@PathVariable Long memberId, @RequestParam String date) {
         return ResponseEntity.ok(diaryService.findByDate(memberId, date));
     }
+
+    /**
+     * 대표 일기(오늘의 좋아요 가장 많은 받은 일기 10개)
+     * memberId: 해당 일기에 대한 작성자의 좋아요 유무를 판단하기 위해 필요
+     */
+    @GetMapping("/popularity/{memberId}")
+    public ResponseEntity<?> todayPopularDiary(@PathVariable Long memberId) {
+        return ResponseEntity.ok(diaryService.popularDiary(memberId));
+    }
 }

--- a/src/main/java/chzzk/grassdiary/web/controller/DiaryController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/DiaryController.java
@@ -1,0 +1,26 @@
+package chzzk.grassdiary.web.controller;
+
+import chzzk.grassdiary.service.DiaryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/diary")
+public class DiaryController {
+    private final DiaryService diaryService;
+
+    /**
+     * 유저별 날짜에 따른 일기 검색(잔디 클릭시 사용)
+     * API 형식: api/diary/1?date=2024-02-21
+     */
+    @GetMapping("/{memberId}")
+    public ResponseEntity<?> searchByDate(@PathVariable Long memberId, @RequestParam String date) {
+        return ResponseEntity.ok(diaryService.findByDate(memberId, date));
+    }
+}

--- a/src/main/java/chzzk/grassdiary/web/controller/GrassController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/GrassController.java
@@ -5,19 +5,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
-public class MyPageController {
-    private final MyPageService myPageService;
+@RequestMapping("/api/grass")
+public class GrassController {
+    MyPageService myPageService;
 
-    @GetMapping("api/profile/{memberId}")
-    public ResponseEntity<?> getProfileInfo(@PathVariable Long memberId) {
-        return ResponseEntity.ok(myPageService.findProfileById(memberId));
-    }
-
-    @GetMapping("api/grass/{memberId}")
+    @GetMapping("{memberId}")
     public ResponseEntity<?> getGrassHistory(@PathVariable Long memberId) {
         return ResponseEntity.ok(myPageService.findGrassHistoryById(memberId));
     }

--- a/src/main/java/chzzk/grassdiary/web/controller/GrassController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/GrassController.java
@@ -1,5 +1,6 @@
 package chzzk.grassdiary.web.controller;
 
+import chzzk.grassdiary.service.DiaryService;
 import chzzk.grassdiary.service.MyPageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,8 +13,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/grass")
 public class GrassController {
-    MyPageService myPageService;
+    private final MyPageService myPageService;
 
+    /**
+     * 사용자의 전체 잔디
+     */
     @GetMapping("{memberId}")
     public ResponseEntity<?> getGrassHistory(@PathVariable Long memberId) {
         return ResponseEntity.ok(myPageService.findGrassHistoryById(memberId));

--- a/src/main/java/chzzk/grassdiary/web/controller/GrassController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/GrassController.java
@@ -22,9 +22,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class GrassController {
     private final MyPageService myPageService;
 
-    /**
-     * 사용자의 전체 잔디
-     */
     @GetMapping("{memberId}")
     @Operation(
             summary = "사용자 전체 잔디 불러오기",

--- a/src/main/java/chzzk/grassdiary/web/controller/GrassController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/GrassController.java
@@ -1,7 +1,13 @@
 package chzzk.grassdiary.web.controller;
 
-import chzzk.grassdiary.service.DiaryService;
 import chzzk.grassdiary.service.MyPageService;
+import chzzk.grassdiary.web.dto.member.GrassInfoDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/grass")
+@Tag(name = "잔디 컨트롤러")
 public class GrassController {
     private final MyPageService myPageService;
 
@@ -19,6 +26,11 @@ public class GrassController {
      * 사용자의 전체 잔디
      */
     @GetMapping("{memberId}")
+    @Operation(
+            summary = "사용자 전체 잔디 불러오기",
+            description = "")
+    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = GrassInfoDTO.class)))
+    @Parameter(name = "memberId", description = "멤버 아이디")
     public ResponseEntity<?> getGrassHistory(@PathVariable Long memberId) {
         return ResponseEntity.ok(myPageService.findGrassHistoryById(memberId));
     }

--- a/src/main/java/chzzk/grassdiary/web/controller/MainController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/MainController.java
@@ -4,14 +4,16 @@ import chzzk.grassdiary.service.MainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
+@RequestMapping("/api")
 public class MainController {
     private final MainService mainService;
 
-    @GetMapping("api/todayInfo")
+    @GetMapping("todayInfo")
     public ResponseEntity<?> todayInfo() {
         return ResponseEntity.ok(mainService.getTodayInfo());
     }

--- a/src/main/java/chzzk/grassdiary/web/controller/MainController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/MainController.java
@@ -1,0 +1,20 @@
+package chzzk.grassdiary.web.controller;
+
+import chzzk.grassdiary.service.MainService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("main")
+public class MainController {
+    private final MainService mainService;
+
+    @GetMapping("api/todayInfo")
+    public ResponseEntity<?> todayInfo() {
+        return ResponseEntity.ok(mainService.getTodayInfo());
+    }
+}

--- a/src/main/java/chzzk/grassdiary/web/controller/MainController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/MainController.java
@@ -4,7 +4,6 @@ import chzzk.grassdiary.service.DiaryService;
 import chzzk.grassdiary.service.MainService;
 import chzzk.grassdiary.web.dto.diary.CountAndMonthGrassDTO;
 import chzzk.grassdiary.web.dto.main.TodayInfoDTO;
-import chzzk.grassdiary.web.dto.member.GrassInfoDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;

--- a/src/main/java/chzzk/grassdiary/web/controller/MainController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/MainController.java
@@ -1,20 +1,31 @@
 package chzzk.grassdiary.web.controller;
 
+import chzzk.grassdiary.service.DiaryService;
 import chzzk.grassdiary.service.MainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/main")
 public class MainController {
     private final MainService mainService;
+    private final DiaryService diaryService;
 
-    @GetMapping("todayInfo")
+    @GetMapping("/todayInfo")
     public ResponseEntity<?> todayInfo() {
         return ResponseEntity.ok(mainService.getTodayInfo());
+    }
+
+    /**
+     * 사용자의 현재까지의 잔디(일기) 개수
+     */
+    @GetMapping("/grassCount/{memberId}")
+    public ResponseEntity<?> getGrassCount(@PathVariable Long memberId) {
+        return ResponseEntity.ok(diaryService.countAll(memberId));
     }
 }

--- a/src/main/java/chzzk/grassdiary/web/controller/MainController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/MainController.java
@@ -4,12 +4,10 @@ import chzzk.grassdiary.service.MainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("main")
 public class MainController {
     private final MainService mainService;
 

--- a/src/main/java/chzzk/grassdiary/web/controller/MainController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/MainController.java
@@ -22,10 +22,10 @@ public class MainController {
     }
 
     /**
-     * 사용자의 현재까지의 잔디(일기) 개수
+     * 사용자의 현재까지의 잔디(일기) 개수, 이번달 잔디 기록
      */
-    @GetMapping("/grassCount/{memberId}")
-    public ResponseEntity<?> getGrassCount(@PathVariable Long memberId) {
-        return ResponseEntity.ok(diaryService.countAll(memberId));
+    @GetMapping("/grass/{memberId}")
+    public ResponseEntity<?> getGrassCountAndMonthGrass(@PathVariable Long memberId) {
+        return ResponseEntity.ok(diaryService.countAllAndMonthGrass(memberId));
     }
 }

--- a/src/main/java/chzzk/grassdiary/web/controller/MainController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/MainController.java
@@ -2,6 +2,15 @@ package chzzk.grassdiary.web.controller;
 
 import chzzk.grassdiary.service.DiaryService;
 import chzzk.grassdiary.service.MainService;
+import chzzk.grassdiary.web.dto.diary.CountAndMonthGrassDTO;
+import chzzk.grassdiary.web.dto.main.TodayInfoDTO;
+import chzzk.grassdiary.web.dto.member.GrassInfoDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,19 +21,24 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/main")
+@Tag(name = "메인 페이지에서 사용하는 컨트롤러")
 public class MainController {
     private final MainService mainService;
     private final DiaryService diaryService;
 
     @GetMapping("/todayInfo")
+    @Operation(summary = "오늘 정보", description = "date(String:`오늘은 MM월 dd일입니다.`), todayQuestion(String):`오늘의 질문`")
+    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = TodayInfoDTO.class)))
     public ResponseEntity<?> todayInfo() {
         return ResponseEntity.ok(mainService.getTodayInfo());
     }
 
-    /**
-     * 사용자의 현재까지의 잔디(일기) 개수, 이번달 잔디 기록
-     */
     @GetMapping("/grass/{memberId}")
+    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = CountAndMonthGrassDTO.class)))
+    @Operation(
+            summary = "사용자의 현재 총 일기 개수, 이번 달 잔디 기록",
+            description = "사용자의 현재까지의 총 잔디(일기) 개수, 이번달 잔디 기록")
+    @Parameter(name = "memberId", description = "멤버 아이디")
     public ResponseEntity<?> getGrassCountAndMonthGrass(@PathVariable Long memberId) {
         return ResponseEntity.ok(diaryService.countAllAndMonthGrass(memberId));
     }

--- a/src/main/java/chzzk/grassdiary/web/controller/MemberController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/MemberController.java
@@ -32,10 +32,7 @@ public class MemberController {
     public ResponseEntity<?> getProfileInfo(@PathVariable Long memberId) {
         return ResponseEntity.ok(myPageService.findProfileById(memberId));
     }
-
-    /**
-     * 사용자의 리워드 포인트 반환
-     */
+    
     @GetMapping("totalReward/{memberId}")
     @Operation(
             summary = "멤버의 누적 리워드 정보",

--- a/src/main/java/chzzk/grassdiary/web/controller/MemberController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/MemberController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/member")
 public class MemberController {
-    MyPageService myPageService;
+    private final MyPageService myPageService;
 
     @GetMapping("profile/{memberId}")
     public ResponseEntity<?> getProfileInfo(@PathVariable Long memberId) {

--- a/src/main/java/chzzk/grassdiary/web/controller/MemberController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/MemberController.java
@@ -1,0 +1,21 @@
+package chzzk.grassdiary.web.controller;
+
+import chzzk.grassdiary.service.MyPageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/member")
+public class MemberController {
+    MyPageService myPageService;
+
+    @GetMapping("profile/{memberId}")
+    public ResponseEntity<?> getProfileInfo(@PathVariable Long memberId) {
+        return ResponseEntity.ok(myPageService.findProfileById(memberId));
+    }
+}

--- a/src/main/java/chzzk/grassdiary/web/controller/MemberController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/MemberController.java
@@ -18,4 +18,12 @@ public class MemberController {
     public ResponseEntity<?> getProfileInfo(@PathVariable Long memberId) {
         return ResponseEntity.ok(myPageService.findProfileById(memberId));
     }
+
+    /**
+     * 사용자의 리워드 포인트 반환
+     */
+    @GetMapping("totalReward/{memberId}")
+    public ResponseEntity<?> getTotalReward(@PathVariable Long memberId) {
+        return ResponseEntity.ok(myPageService.findTotalRewardById(memberId));
+    }
 }

--- a/src/main/java/chzzk/grassdiary/web/controller/MemberController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/MemberController.java
@@ -1,6 +1,14 @@
 package chzzk.grassdiary.web.controller;
 
 import chzzk.grassdiary.service.MyPageService;
+import chzzk.grassdiary.web.dto.member.MemberInfoDTO;
+import chzzk.grassdiary.web.dto.member.TotalRewardDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,10 +19,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/member")
+@Tag(name = "멤버 컨트롤러")
 public class MemberController {
     private final MyPageService myPageService;
 
     @GetMapping("profile/{memberId}")
+    @Operation(
+            summary = "멤버의 프로필 기본 정보",
+            description = "이미지 URL, 닉네임, 한줄 소개")
+    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = MemberInfoDTO.class)))
+    @Parameter(name = "memberId", description = "멤버 아이디")
     public ResponseEntity<?> getProfileInfo(@PathVariable Long memberId) {
         return ResponseEntity.ok(myPageService.findProfileById(memberId));
     }
@@ -23,6 +37,11 @@ public class MemberController {
      * 사용자의 리워드 포인트 반환
      */
     @GetMapping("totalReward/{memberId}")
+    @Operation(
+            summary = "멤버의 누적 리워드 정보",
+            description = "")
+    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = TotalRewardDTO.class)))
+    @Parameter(name = "memberId", description = "멤버 아이디")
     public ResponseEntity<?> getTotalReward(@PathVariable Long memberId) {
         return ResponseEntity.ok(myPageService.findTotalRewardById(memberId));
     }

--- a/src/main/java/chzzk/grassdiary/web/controller/MyPageController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/MyPageController.java
@@ -18,4 +18,9 @@ public class MyPageController {
     public ResponseEntity<?> getProfileInfo(@PathVariable Long memberId) {
         return ResponseEntity.ok(myPageService.findProfileById(memberId));
     }
+
+    @GetMapping("api/grass/{memberId}")
+    public ResponseEntity<?> getGrassHistory(@PathVariable Long memberId) {
+        return ResponseEntity.ok(myPageService.findGrassHistoryById(memberId));
+    }
 }

--- a/src/main/java/chzzk/grassdiary/web/controller/MyPageController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/MyPageController.java
@@ -1,0 +1,21 @@
+package chzzk.grassdiary.web.controller;
+
+import chzzk.grassdiary.service.MyPageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("myPage")
+public class MyPageController {
+    private final MyPageService myPageService;
+
+    @GetMapping("api/profile/{memberId}")
+    public ResponseEntity<?> getProfileInfo(@PathVariable Long memberId) {
+        return ResponseEntity.ok(myPageService.findProfileById(memberId));
+    }
+}

--- a/src/main/java/chzzk/grassdiary/web/controller/MyPageController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/MyPageController.java
@@ -5,12 +5,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("myPage")
 public class MyPageController {
     private final MyPageService myPageService;
 

--- a/src/main/java/chzzk/grassdiary/web/controller/SearchController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/SearchController.java
@@ -25,9 +25,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class SearchController {
     private final TagService tagService;
 
-    /**
-     * 유저의 해시태그 리스트 반환
-     */
     @GetMapping("hashTag/{memberId}")
     @Operation(
             summary = "유저가 사용한 해시태그 리스트",
@@ -38,9 +35,6 @@ public class SearchController {
         return ResponseEntity.ok(tagService.getMemberTags(memberId));
     }
 
-    /**
-     * 유저가 해시태그를 선택하면 그에 대한 다이어리 반환
-     */
     @GetMapping("tagId/{memberId}")
     @Operation(
             summary = "해시태그에 대한 다이어리 검색",

--- a/src/main/java/chzzk/grassdiary/web/controller/SearchController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/SearchController.java
@@ -1,0 +1,30 @@
+package chzzk.grassdiary.web.controller;
+
+import chzzk.grassdiary.service.TagService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/search")
+public class SearchController {
+    TagService tagService;
+
+    /**
+     * 유저의 해시태그 리스트 반환
+     * @param memberId
+     * @return List<TagDTO>
+     */
+    @GetMapping("hashTag/{memberId}")
+    public ResponseEntity<?> searchHashTag(@PathVariable Long memberId) {
+        return ResponseEntity.ok(tagService.getMemberTags(memberId));
+    }
+
+    /**
+     * 유저가 해시태그를 선택하면 그에 대한 다이어리 반환
+     */
+}

--- a/src/main/java/chzzk/grassdiary/web/controller/SearchController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/SearchController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/search")
 public class SearchController {
-    TagService tagService;
+    private final TagService tagService;
 
     /**
      * 유저의 해시태그 리스트 반환

--- a/src/main/java/chzzk/grassdiary/web/controller/SearchController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/SearchController.java
@@ -1,6 +1,15 @@
 package chzzk.grassdiary.web.controller;
 
 import chzzk.grassdiary.service.TagService;
+import chzzk.grassdiary.web.dto.diary.DiaryDTO;
+import chzzk.grassdiary.web.dto.diary.TagDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,15 +21,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/search")
+@Tag(name = "검색 컨트롤러")
 public class SearchController {
     private final TagService tagService;
 
     /**
      * 유저의 해시태그 리스트 반환
-     * @param memberId
-     * @return List<TagDTO>
      */
     @GetMapping("hashTag/{memberId}")
+    @Operation(
+            summary = "유저가 사용한 해시태그 리스트",
+            description = "")
+    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = TagDTO.class)))
+    @Parameter(name = "memberId", description = "멤버 아이디")
     public ResponseEntity<?> searchHashTag(@PathVariable Long memberId) {
         return ResponseEntity.ok(tagService.getMemberTags(memberId));
     }
@@ -29,6 +42,14 @@ public class SearchController {
      * 유저가 해시태그를 선택하면 그에 대한 다이어리 반환
      */
     @GetMapping("tagId/{memberId}")
+    @Operation(
+            summary = "해시태그에 대한 다이어리 검색",
+            description = "유저가 해시태그를 선택하면 해당 해시태그를 사용한 다이어리 리스트를 반환")
+    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = DiaryDTO.class)))
+    @Parameters({
+            @Parameter(name = "memberId", description = "멤버 아이디"),
+            @Parameter(name = "tagId", description = "검색을 원하는 해시태그 아이디")
+    })
     public ResponseEntity<?> findByHashTagId(@PathVariable Long memberId, @RequestParam Long tagId) {
         return ResponseEntity.ok(tagService.findByHashTagId(memberId, tagId));
     }

--- a/src/main/java/chzzk/grassdiary/web/controller/SearchController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/SearchController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -27,4 +28,8 @@ public class SearchController {
     /**
      * 유저가 해시태그를 선택하면 그에 대한 다이어리 반환
      */
+    @GetMapping("tagId/{memberId}")
+    public ResponseEntity<?> findByHashTagId(@PathVariable Long memberId, @RequestParam Long tagId) {
+        return ResponseEntity.ok(tagService.findByHashTagId(memberId, tagId));
+    }
 }

--- a/src/main/java/chzzk/grassdiary/web/dto/diary/CountAndMonthGrassDTO.java
+++ b/src/main/java/chzzk/grassdiary/web/dto/diary/CountAndMonthGrassDTO.java
@@ -1,0 +1,6 @@
+package chzzk.grassdiary.web.dto.diary;
+
+import chzzk.grassdiary.web.dto.member.GrassInfoDTO;
+
+public record CountAndMonthGrassDTO (Integer count, GrassInfoDTO grassInfoDTO){
+}

--- a/src/main/java/chzzk/grassdiary/web/dto/diary/CountAndMonthGrassDTO.java
+++ b/src/main/java/chzzk/grassdiary/web/dto/diary/CountAndMonthGrassDTO.java
@@ -2,5 +2,5 @@ package chzzk.grassdiary.web.dto.diary;
 
 import chzzk.grassdiary.web.dto.member.GrassInfoDTO;
 
-public record CountAndMonthGrassDTO (Integer count, GrassInfoDTO grassInfoDTO){
+public record CountAndMonthGrassDTO(Integer count, GrassInfoDTO grassInfoDTO) {
 }

--- a/src/main/java/chzzk/grassdiary/web/dto/diary/CountDTO.java
+++ b/src/main/java/chzzk/grassdiary/web/dto/diary/CountDTO.java
@@ -1,0 +1,4 @@
+package chzzk.grassdiary.web.dto.diary;
+
+public record CountDTO(Integer count) {
+}

--- a/src/main/java/chzzk/grassdiary/web/dto/diary/CountDTO.java
+++ b/src/main/java/chzzk/grassdiary/web/dto/diary/CountDTO.java
@@ -1,4 +1,0 @@
-package chzzk.grassdiary.web.dto.diary;
-
-public record CountDTO(Integer count) {
-}

--- a/src/main/java/chzzk/grassdiary/web/dto/diary/DiaryDTO.java
+++ b/src/main/java/chzzk/grassdiary/web/dto/diary/DiaryDTO.java
@@ -1,13 +1,13 @@
 package chzzk.grassdiary.web.dto.diary;
 
-import chzzk.grassdiary.domain.diary.tag.MemberTags;
+import chzzk.grassdiary.domain.diary.tag.TagList;
 
 import java.util.List;
 
 public record DiaryDTO (
         Long diaryId,
         String content,
-        List<MemberTags> tags,
+        List<TagList> tags,
         Float transparency,
         Boolean isPrivate,
         Integer likeCount,

--- a/src/main/java/chzzk/grassdiary/web/dto/diary/DiaryDTO.java
+++ b/src/main/java/chzzk/grassdiary/web/dto/diary/DiaryDTO.java
@@ -1,7 +1,9 @@
 package chzzk.grassdiary.web.dto.diary;
 
+import chzzk.grassdiary.domain.diary.Diary;
 import chzzk.grassdiary.domain.diary.tag.TagList;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 public record DiaryDTO (
@@ -14,4 +16,16 @@ public record DiaryDTO (
         String createdDate,
         String createdAt
 ) {
+    public static DiaryDTO from(Diary diary, List<TagList> tags) {
+        return new DiaryDTO(
+                diary.getId(),
+                diary.getContent(),
+                tags,
+                diary.getConditionLevel().getTransparency(),
+                diary.getIsPrivate(),
+                diary.getDiaryLikes().size(),
+                diary.getCreatedAt().format(DateTimeFormatter.ofPattern("yy년 MM월 dd일")),
+                diary.getCreatedAt().format(DateTimeFormatter.ofPattern("HH:mm"))
+        );
+    }
 }

--- a/src/main/java/chzzk/grassdiary/web/dto/diary/DiaryDTO.java
+++ b/src/main/java/chzzk/grassdiary/web/dto/diary/DiaryDTO.java
@@ -2,11 +2,10 @@ package chzzk.grassdiary.web.dto.diary;
 
 import chzzk.grassdiary.domain.diary.Diary;
 import chzzk.grassdiary.domain.diary.tag.TagList;
-
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
-public record DiaryDTO (
+public record DiaryDTO(
         Long diaryId,
         String content,
         List<TagList> tags,

--- a/src/main/java/chzzk/grassdiary/web/dto/diary/DiaryDTO.java
+++ b/src/main/java/chzzk/grassdiary/web/dto/diary/DiaryDTO.java
@@ -1,0 +1,17 @@
+package chzzk.grassdiary.web.dto.diary;
+
+import chzzk.grassdiary.domain.diary.tag.MemberTags;
+
+import java.util.List;
+
+public record DiaryDTO (
+        Long diaryId,
+        String content,
+        List<MemberTags> tags,
+        Float transparency,
+        Boolean isPrivate,
+        Integer likeCount,
+        String createdDate,
+        String createdAt
+) {
+}

--- a/src/main/java/chzzk/grassdiary/web/dto/diary/PopularDiaryDTO.java
+++ b/src/main/java/chzzk/grassdiary/web/dto/diary/PopularDiaryDTO.java
@@ -1,4 +1,4 @@
 package chzzk.grassdiary.web.dto.diary;
 
-public record PopularDiaryDTO(Long diaryId, String content, Boolean isLiked){
+public record PopularDiaryDTO(Long diaryId, String content, Boolean isLiked) {
 }

--- a/src/main/java/chzzk/grassdiary/web/dto/diary/PopularDiaryDTO.java
+++ b/src/main/java/chzzk/grassdiary/web/dto/diary/PopularDiaryDTO.java
@@ -1,0 +1,4 @@
+package chzzk.grassdiary.web.dto.diary;
+
+public record PopularDiaryDTO(Long diaryId, String content, Boolean isLiked){
+}

--- a/src/main/java/chzzk/grassdiary/web/dto/diary/TagDTO.java
+++ b/src/main/java/chzzk/grassdiary/web/dto/diary/TagDTO.java
@@ -1,0 +1,4 @@
+package chzzk.grassdiary.web.dto.diary;
+
+public record TagDTO (Long tagId, String tag){
+}

--- a/src/main/java/chzzk/grassdiary/web/dto/diary/TagDTO.java
+++ b/src/main/java/chzzk/grassdiary/web/dto/diary/TagDTO.java
@@ -1,4 +1,4 @@
 package chzzk.grassdiary.web.dto.diary;
 
-public record TagDTO (Long tagId, String tag){
+public record TagDTO(Long tagId, String tag) {
 }

--- a/src/main/java/chzzk/grassdiary/web/dto/main/TodayInfoDTO.java
+++ b/src/main/java/chzzk/grassdiary/web/dto/main/TodayInfoDTO.java
@@ -1,0 +1,4 @@
+package chzzk.grassdiary.web.dto.main;
+
+public record TodayInfoDTO(String date, String todayQuestion) {
+}

--- a/src/main/java/chzzk/grassdiary/web/dto/member/GrassInfo.java
+++ b/src/main/java/chzzk/grassdiary/web/dto/member/GrassInfo.java
@@ -1,0 +1,5 @@
+package chzzk.grassdiary.web.dto.member;
+
+
+public record GrassInfo(String createdAt, Float transparency) {
+}

--- a/src/main/java/chzzk/grassdiary/web/dto/member/GrassInfoDTO.java
+++ b/src/main/java/chzzk/grassdiary/web/dto/member/GrassInfoDTO.java
@@ -1,0 +1,23 @@
+package chzzk.grassdiary.web.dto.member;
+
+import chzzk.grassdiary.domain.diary.Diary;
+import lombok.Getter;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class GrassInfoDTO {
+    List<GrassInfo> grassList;
+    String colorRGB;
+
+    public GrassInfoDTO(List<Diary> diaryHistory, String rgb) {
+        grassList = diaryHistory.stream()
+                .map(diary -> new GrassInfo(
+                        diary.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
+                        diary.getConditionLevel().getTransparency()))
+                .collect(Collectors.toList());
+        colorRGB = rgb;
+    }
+}

--- a/src/main/java/chzzk/grassdiary/web/dto/member/GrassInfoDTO.java
+++ b/src/main/java/chzzk/grassdiary/web/dto/member/GrassInfoDTO.java
@@ -1,11 +1,10 @@
 package chzzk.grassdiary.web.dto.member;
 
 import chzzk.grassdiary.domain.diary.Diary;
-import lombok.Getter;
-
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.Getter;
 
 @Getter
 public class GrassInfoDTO {

--- a/src/main/java/chzzk/grassdiary/web/dto/member/MemberInfoDTO.java
+++ b/src/main/java/chzzk/grassdiary/web/dto/member/MemberInfoDTO.java
@@ -1,0 +1,8 @@
+package chzzk.grassdiary.web.dto.member;
+
+public record MemberInfoDTO(
+        String profileImageURL,
+        String nickName,
+        String profileIntro
+) {
+}

--- a/src/main/java/chzzk/grassdiary/web/dto/member/TotalRewardDTO.java
+++ b/src/main/java/chzzk/grassdiary/web/dto/member/TotalRewardDTO.java
@@ -1,0 +1,4 @@
+package chzzk.grassdiary.web.dto.member;
+
+public record TotalRewardDTO(Integer rewardPoint) {
+}

--- a/src/test/java/chzzk/grassdiary/service/DiaryServiceTest.java
+++ b/src/test/java/chzzk/grassdiary/service/DiaryServiceTest.java
@@ -1,0 +1,96 @@
+package chzzk.grassdiary.service;
+
+import chzzk.grassdiary.domain.color.ConditionLevel;
+import chzzk.grassdiary.domain.diary.Diary;
+import chzzk.grassdiary.domain.diary.DiaryRepository;
+import chzzk.grassdiary.domain.diary.tag.DiaryTag;
+import chzzk.grassdiary.domain.diary.tag.DiaryTagRepository;
+import chzzk.grassdiary.domain.diary.tag.MemberTags;
+import chzzk.grassdiary.domain.diary.tag.MemberTagsRepository;
+import chzzk.grassdiary.domain.diary.tag.TagList;
+import chzzk.grassdiary.domain.diary.tag.TagListRepository;
+import chzzk.grassdiary.domain.member.Member;
+import chzzk.grassdiary.domain.member.MemberRepository;
+import chzzk.grassdiary.web.dto.diary.DiaryDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class DiaryServiceTest {
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    DiaryRepository diaryRepository;
+    @Autowired
+    MemberTagsRepository memberTagsRepository;
+    @Autowired
+    TagListRepository tagListRepository;
+    @Autowired
+    DiaryTagRepository diaryTagRepository;
+
+    @Autowired
+    DiaryService diaryService;
+
+    protected List<Member> members;
+    protected List<Diary> diaries;
+    protected List<DiaryTag> diaryTags;
+    protected List<MemberTags> memberTags;
+    protected List<TagList> tagLists;
+
+    @BeforeEach
+    void beforeEach() {
+        // 멤버 3명 만들기
+        members = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            members.add(Member.builder()
+                    .nickname("testMember" + i)
+                    .email("member" + i + "@test.com")
+                    .build());
+        }
+        members = memberRepository.saveAll(members);
+
+        // 일기 추가
+        diaries = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            diaries.add(Diary.builder()
+                    .member(members.get(i%3))
+                    .content("testContent" + i)
+                    .hasTag(false)
+                    .conditionLevel(ConditionLevel.LEVEL_5)
+                    .build());
+        }
+        diaries = diaryRepository.saveAll(diaries);
+    }
+
+    /**
+     * 유저의 날짜별 일기 검색(잔디 클릭시 실행)
+     * Web에서 DB에 값 집어넣고 테스트 해보면 작동하나 테스트 코드는 실패함. 테스트 코드 수정이 필요함.
+     */
+    @Test
+    void findByDate() {
+        // Given
+        Long memberId = members.get(0).getId();
+
+        System.out.println("memberId:" + memberId + ", today: " + LocalDate.now().format(DateTimeFormatter.ISO_DATE));
+        // When
+        DiaryDTO diaryDTO = diaryService.findByDate(memberId, LocalDate.now().format(DateTimeFormatter.ISO_DATE));
+
+        System.out.println("다이어리 사이즈: "+diaries.size());
+        System.out.println("1번 다이어리: " + diaries.get(0).getContent());
+        // Then
+        assertThat(diaryDTO).isNotNull();
+        assertThat(diaryDTO.content()).isEqualTo("testContent0");
+        assertThat(diaryDTO.createdDate()).isEqualTo(LocalDate.now().format(DateTimeFormatter.ofPattern("yy년 MM월 dd일")));
+
+    }
+}

--- a/src/test/java/chzzk/grassdiary/service/DiaryServiceTest.java
+++ b/src/test/java/chzzk/grassdiary/service/DiaryServiceTest.java
@@ -1,25 +1,24 @@
 package chzzk.grassdiary.service;
 
+import chzzk.grassdiary.domain.color.ColorCode;
+import chzzk.grassdiary.domain.color.ColorCodeRepository;
 import chzzk.grassdiary.domain.color.ConditionLevel;
 import chzzk.grassdiary.domain.diary.Diary;
 import chzzk.grassdiary.domain.diary.DiaryRepository;
-import chzzk.grassdiary.domain.diary.tag.DiaryTag;
 import chzzk.grassdiary.domain.diary.tag.DiaryTagRepository;
-import chzzk.grassdiary.domain.diary.tag.MemberTags;
 import chzzk.grassdiary.domain.diary.tag.MemberTagsRepository;
-import chzzk.grassdiary.domain.diary.tag.TagList;
 import chzzk.grassdiary.domain.diary.tag.TagListRepository;
 import chzzk.grassdiary.domain.member.Member;
 import chzzk.grassdiary.domain.member.MemberRepository;
-import chzzk.grassdiary.web.dto.diary.CountDTO;
+import chzzk.grassdiary.web.dto.diary.CountAndMonthGrassDTO;
 import chzzk.grassdiary.web.dto.diary.DiaryDTO;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
@@ -38,24 +37,33 @@ class DiaryServiceTest {
     TagListRepository tagListRepository;
     @Autowired
     DiaryTagRepository diaryTagRepository;
+    @Autowired
+    ColorCodeRepository colorCodeRepository;
 
     @Autowired
     DiaryService diaryService;
 
     protected List<Member> members;
     protected List<Diary> diaries;
-    protected List<DiaryTag> diaryTags;
-    protected List<MemberTags> memberTags;
-    protected List<TagList> tagLists;
+    protected List<ColorCode> colorCodes;
 
     @BeforeEach
     void beforeEach() {
+        // 컬러코드 값 넣기
+        colorCodes = new ArrayList<>();
+        colorCodes.add(ColorCode.builder()
+                        .colorName("GREEN")
+                        .rgb("000,000,000")
+                        .build());
+        colorCodes = colorCodeRepository.saveAll(colorCodes);
+
         // 멤버 3명 만들기
         members = new ArrayList<>();
         for (int i = 0; i < 3; i++) {
             members.add(Member.builder()
                     .nickname("testMember" + i)
                     .email("member" + i + "@test.com")
+                    .currentColorCode(colorCodes.get(0))
                     .build());
         }
         members = memberRepository.saveAll(members);
@@ -73,21 +81,15 @@ class DiaryServiceTest {
         diaries = diaryRepository.saveAll(diaries);
     }
 
-    /**
-     * 유저의 날짜별 일기 검색(잔디 클릭시 실행)
-     * Web에서 DB에 값 집어넣고 테스트 해보면 작동하나 테스트 코드는 실패함. 테스트 코드 수정이 필요함.
-     */
     @Test
+    @DisplayName("유저의 날짜별 일기 검색(잔디 클릭시 실행)")
     void findByDate() {
         // Given
         Long memberId = members.get(0).getId();
 
-        System.out.println("memberId:" + memberId + ", today: " + LocalDate.now().format(DateTimeFormatter.ISO_DATE));
         // When
         DiaryDTO diaryDTO = diaryService.findByDate(memberId, LocalDate.now().format(DateTimeFormatter.ISO_DATE));
 
-        System.out.println("다이어리 사이즈: "+diaries.size());
-        System.out.println("1번 다이어리: " + diaries.get(0).getContent());
         // Then
         assertThat(diaryDTO).isNotNull();
         assertThat(diaryDTO.content()).isEqualTo("testContent0");
@@ -96,15 +98,17 @@ class DiaryServiceTest {
     }
 
     @Test
-    void countAll() {
+    @DisplayName("유저별 모든 일기 개수, 이번 달 잔디 정보 검색")
+    void countAllAndMonthGrass() {
         // Given
         Long memberId = members.get(0).getId();
 
         // When
-        CountDTO countDTO = diaryService.countAll(memberId);
+        CountAndMonthGrassDTO countAndMonthGrass = diaryService.countAllAndMonthGrass(memberId);
 
         // Then
-        assertThat(countDTO).isNotNull();
-        assertThat(countDTO.count()).isEqualTo(1);
+        assertThat(countAndMonthGrass).isNotNull();
+        assertThat(countAndMonthGrass.count()).isEqualTo(1);
+        assertThat(countAndMonthGrass.grassInfoDTO().getGrassList().size()).isEqualTo(1);
     }
 }

--- a/src/test/java/chzzk/grassdiary/service/DiaryServiceTest.java
+++ b/src/test/java/chzzk/grassdiary/service/DiaryServiceTest.java
@@ -11,6 +11,7 @@ import chzzk.grassdiary.domain.diary.tag.TagList;
 import chzzk.grassdiary.domain.diary.tag.TagListRepository;
 import chzzk.grassdiary.domain.member.Member;
 import chzzk.grassdiary.domain.member.MemberRepository;
+import chzzk.grassdiary.web.dto.diary.CountDTO;
 import chzzk.grassdiary.web.dto.diary.DiaryDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -92,5 +93,18 @@ class DiaryServiceTest {
         assertThat(diaryDTO.content()).isEqualTo("testContent0");
         assertThat(diaryDTO.createdDate()).isEqualTo(LocalDate.now().format(DateTimeFormatter.ofPattern("yy년 MM월 dd일")));
 
+    }
+
+    @Test
+    void countAll() {
+        // Given
+        Long memberId = members.get(0).getId();
+
+        // When
+        CountDTO countDTO = diaryService.countAll(memberId);
+
+        // Then
+        assertThat(countDTO).isNotNull();
+        assertThat(countDTO.count()).isEqualTo(1);
     }
 }

--- a/src/test/java/chzzk/grassdiary/service/DiaryServiceTest.java
+++ b/src/test/java/chzzk/grassdiary/service/DiaryServiceTest.java
@@ -1,5 +1,7 @@
 package chzzk.grassdiary.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import chzzk.grassdiary.domain.color.ColorCode;
 import chzzk.grassdiary.domain.color.ColorCodeRepository;
 import chzzk.grassdiary.domain.color.ConditionLevel;
@@ -12,18 +14,15 @@ import chzzk.grassdiary.domain.member.Member;
 import chzzk.grassdiary.domain.member.MemberRepository;
 import chzzk.grassdiary.web.dto.diary.CountAndMonthGrassDTO;
 import chzzk.grassdiary.web.dto.diary.DiaryDTO;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 class DiaryServiceTest {
@@ -52,9 +51,9 @@ class DiaryServiceTest {
         // 컬러코드 값 넣기
         colorCodes = new ArrayList<>();
         colorCodes.add(ColorCode.builder()
-                        .colorName("GREEN")
-                        .rgb("000,000,000")
-                        .build());
+                .colorName("GREEN")
+                .rgb("000,000,000")
+                .build());
         colorCodes = colorCodeRepository.saveAll(colorCodes);
 
         // 멤버 3명 만들기
@@ -72,7 +71,7 @@ class DiaryServiceTest {
         diaries = new ArrayList<>();
         for (int i = 0; i < 3; i++) {
             diaries.add(Diary.builder()
-                    .member(members.get(i%3))
+                    .member(members.get(i % 3))
                     .content("testContent" + i)
                     .hasTag(false)
                     .conditionLevel(ConditionLevel.LEVEL_5)
@@ -93,7 +92,8 @@ class DiaryServiceTest {
         // Then
         assertThat(diaryDTO).isNotNull();
         assertThat(diaryDTO.content()).isEqualTo("testContent0");
-        assertThat(diaryDTO.createdDate()).isEqualTo(LocalDate.now().format(DateTimeFormatter.ofPattern("yy년 MM월 dd일")));
+        assertThat(diaryDTO.createdDate()).isEqualTo(
+                LocalDate.now().format(DateTimeFormatter.ofPattern("yy년 MM월 dd일")));
 
     }
 

--- a/src/test/java/chzzk/grassdiary/service/TagServiceTest.java
+++ b/src/test/java/chzzk/grassdiary/service/TagServiceTest.java
@@ -1,0 +1,106 @@
+package chzzk.grassdiary.service;
+
+import chzzk.grassdiary.domain.color.ConditionLevel;
+import chzzk.grassdiary.domain.diary.Diary;
+import chzzk.grassdiary.domain.diary.DiaryRepository;
+import chzzk.grassdiary.domain.diary.tag.DiaryTag;
+import chzzk.grassdiary.domain.diary.tag.MemberTags;
+import chzzk.grassdiary.domain.diary.tag.MemberTagsRepository;
+import chzzk.grassdiary.domain.diary.tag.TagList;
+import chzzk.grassdiary.domain.diary.tag.TagListRepository;
+import chzzk.grassdiary.domain.member.Member;
+import chzzk.grassdiary.domain.member.MemberRepository;
+import chzzk.grassdiary.web.dto.diary.TagDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class TagServiceTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    DiaryRepository diaryRepository;
+
+    @Autowired
+    MemberTagsRepository memberTagsRepository;
+    @Autowired
+    TagListRepository tagListRepository;
+
+    @Autowired
+    TagService tagService;
+
+    protected List<Member> members;
+    protected List<Diary> diaries;
+    protected List<MemberTags> memberTags;
+    protected List<TagList> tagLists;
+
+    @BeforeEach
+    void beforeEach() {
+        // 멤버 3명 만들기
+        members = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            members.add(Member.builder()
+                            .nickname("testMember" + i)
+                            .email("member" + i + "@test.com")
+                            .build());
+        }
+        members = memberRepository.saveAll(members);
+
+        // 15개 일기
+        diaries = new ArrayList<>();
+        for (int i = 0; i < 15; i++) {
+            diaries.add(Diary.builder()
+                            .member(members.get(i%3))
+                            .content("testContent" + i)
+                            .hasTag(true)
+                            .conditionLevel(ConditionLevel.LEVEL_5)
+                    .build());
+        }
+        diaries = diaryRepository.saveAll(diaries);
+
+        // 태그 리스트 생성
+        tagLists = new ArrayList<>();
+        tagLists.add(TagList.builder().tag("tag1").build());
+        tagLists.add(TagList.builder().tag("tag2").build());
+        tagLists.add(TagList.builder().tag("tag3").build());
+        tagLists = tagListRepository.saveAll(tagLists);
+
+        // 멤버 태그 생성
+        memberTags = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            memberTags.add(new MemberTags(members.get(i), tagLists.get(0)));
+            memberTags.add(new MemberTags(members.get(i), tagLists.get(1)));
+        }
+        memberTags.add(new MemberTags(members.get(2), tagLists.get(2)));
+        memberTags = memberTagsRepository.saveAll(memberTags);
+    }
+
+    @Test
+    @DisplayName("멤버별 해시태그 검색")
+    void searchHashTags() {
+        // Given
+        Member member = members.get(2); // 1번 멤버 선택
+        Long memberId = member.getId();
+
+        // When
+        List<TagDTO> dto = tagService.getMemberTags(memberId);
+
+        // Then
+        System.out.println("SIZE: " + dto.size());
+        for (int i = 0; i < dto.size(); i++) {
+            System.out.println("tagId: "+dto.get(i).tagId());
+            System.out.println("tag: "+dto.get(i).tag());
+        }
+        assertThat(dto.size()).isEqualTo(3);
+    }
+
+}

--- a/src/test/java/chzzk/grassdiary/service/TagServiceTest.java
+++ b/src/test/java/chzzk/grassdiary/service/TagServiceTest.java
@@ -1,9 +1,10 @@
 package chzzk.grassdiary.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import chzzk.grassdiary.domain.color.ConditionLevel;
 import chzzk.grassdiary.domain.diary.Diary;
 import chzzk.grassdiary.domain.diary.DiaryRepository;
-import chzzk.grassdiary.domain.diary.tag.DiaryTag;
 import chzzk.grassdiary.domain.diary.tag.MemberTags;
 import chzzk.grassdiary.domain.diary.tag.MemberTagsRepository;
 import chzzk.grassdiary.domain.diary.tag.TagList;
@@ -11,16 +12,13 @@ import chzzk.grassdiary.domain.diary.tag.TagListRepository;
 import chzzk.grassdiary.domain.member.Member;
 import chzzk.grassdiary.domain.member.MemberRepository;
 import chzzk.grassdiary.web.dto.diary.TagDTO;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 class TagServiceTest {
@@ -49,9 +47,9 @@ class TagServiceTest {
         members = new ArrayList<>();
         for (int i = 0; i < 3; i++) {
             members.add(Member.builder()
-                            .nickname("testMember" + i)
-                            .email("member" + i + "@test.com")
-                            .build());
+                    .nickname("testMember" + i)
+                    .email("member" + i + "@test.com")
+                    .build());
         }
         members = memberRepository.saveAll(members);
 
@@ -59,10 +57,10 @@ class TagServiceTest {
         diaries = new ArrayList<>();
         for (int i = 0; i < 15; i++) {
             diaries.add(Diary.builder()
-                            .member(members.get(i%3))
-                            .content("testContent" + i)
-                            .hasTag(true)
-                            .conditionLevel(ConditionLevel.LEVEL_5)
+                    .member(members.get(i % 3))
+                    .content("testContent" + i)
+                    .hasTag(true)
+                    .conditionLevel(ConditionLevel.LEVEL_5)
                     .build());
         }
         diaries = diaryRepository.saveAll(diaries);
@@ -97,8 +95,8 @@ class TagServiceTest {
         // Then
         System.out.println("SIZE: " + dto.size());
         for (int i = 0; i < dto.size(); i++) {
-            System.out.println("tagId: "+dto.get(i).tagId());
-            System.out.println("tag: "+dto.get(i).tag());
+            System.out.println("tagId: " + dto.get(i).tagId());
+            System.out.println("tag: " + dto.get(i).tag());
         }
         assertThat(dto.size()).isEqualTo(3);
     }


### PR DESCRIPTION
## Main Page

완료           | 기능                                 |      상세 설명 | API | URL
----------| --------------------------| ----- | --------| --------|
✅ | 메인 배너 |  오늘 날짜, 오늘의 질문 | GET | api/main/todayInfo
❗ | 메인 배너 | 오늘의 질문 랜덤으로 만들기 | GET | 랜덤 메시지 리스트 필요
✅ | 기록 상자 | 현재까지의 잔디(일기) 개수, 이번달 잔디 기록 | GET | api/main/grass/{memberId}
✅  | 리워드 | 현재까지 쌓인 리워드 보기 | GET | api/member/totalReward/{memberId}
✅ | 이번주Top10 | 대표 일기(오늘의 좋아요 가장 많은 받은 일기 10개) | GET | api/diary/popularity/{memberId}

## My Page

완료           | 기능                                 |      상세 설명 | API | URL 
----------| --------------------------| ----- | --------| --------|
✅ | 프로필 |  profileImageURL, nickName, profileIntro | GET | api/profile/{memberId}
✅ | 잔디 | 모든 잔디 리스트를 보여줌 | GET | api/grass/{memberId}
✅ | 검색 | 유저의 날짜별 일기 반환(잔디 선택시 사용) | GET | api/search/date/{memberId}?date=yyyy-MM-dd
✅ | 일기장 | 최신순 일기 5개씩 반환 | GET | api/diary/main/{memberId}?page=N
✅ | 일기장 | 오래된 순 일기 5개씩 반환 | GET | api/diary/main/{memberId}?page=N&sort=createdAt,ASC
✅ | 검색 | 유저별 해시태그 리스트 반환 | GET | api/search/hashTag/{memberId}
✅ | 검색 | 해시태그 id를 이용하여 일기 리스트 검색 | GET | api/search/tagId/{memberId}?tagId=Integer
