### PR TITLE
feat/signup-signin-page: 소셜 회원가입, 로그인 기능 구현 중 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### oauth setting ###
+src/main/resources/application.yaml
+src/main/resources/application.properties

--- a/build.gradle
+++ b/build.gradle
@@ -1,37 +1,47 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.2.2'
-	id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+    id 'org.springframework.boot' version '3.2.2'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'chzzk'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    compileOnly 'org.projectlombok:lombok'
+
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    annotationProcessor 'org.projectlombok:lombok'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/chzzk/grassdiary/domain/auth/client/GoogleOAuthClient.java
+++ b/src/main/java/chzzk/grassdiary/domain/auth/client/GoogleOAuthClient.java
@@ -1,0 +1,61 @@
+package chzzk.grassdiary.domain.auth.client;
+
+import chzzk.grassdiary.domain.auth.config.GoogleOAuthProperties;
+import chzzk.grassdiary.domain.auth.service.dto.GoogleOAuthToken;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * 스프링 서버가 구글 서버에 인가 코드를 전달하여 액세스 토큰을 받는다.
+ */
+@Component
+public class GoogleOAuthClient implements OAuthClient {
+    private static final String OAUTH_GRANT_TYPE = "authorization_code";
+    private final GoogleOAuthProperties googleOAuthProperties;
+    private final RestTemplate restTemplate;
+
+    public GoogleOAuthClient(GoogleOAuthProperties googleOAuthProperties, RestTemplateBuilder restTemplateBuilder) {
+        this.googleOAuthProperties = googleOAuthProperties;
+        this.restTemplate = restTemplateBuilder.build();
+    }
+
+    @Override
+    public GoogleOAuthToken getGoogleAccessToken(String code, boolean isSignUp) {
+        // header 생성
+        HttpHeaders httpHeaders = createHeaders();
+        // body 생성
+        MultiValueMap<String, String> httpBody = createBody(code, isSignUp);
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(httpBody, httpHeaders);
+        ResponseEntity<GoogleOAuthToken> googleOAuthTokenResponseEntity = restTemplate.postForEntity(
+                googleOAuthProperties.getTokenUri(), request, GoogleOAuthToken.class);
+        return googleOAuthTokenResponseEntity.getBody();
+    }
+
+    private HttpHeaders createHeaders() {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        return httpHeaders;
+    }
+
+    private MultiValueMap<String, String> createBody(String code, boolean isSignUp) {
+        MultiValueMap<String, String> httpBody = new LinkedMultiValueMap<>();
+        httpBody.add("code", code);
+        httpBody.add("client_id", googleOAuthProperties.getClientId());
+        httpBody.add("client_secret", googleOAuthProperties.getClientSecret());
+        // 회원가입, 로그인에 대한 redirect_url이 다르므로 isSignUp으로 판단
+        httpBody.add("redirect_uri", getRedirect_uri(isSignUp));
+        httpBody.add("grant_type", OAUTH_GRANT_TYPE);
+        return httpBody;
+    }
+
+    private String getRedirect_uri(boolean isSignUp) {
+        return isSignUp ? googleOAuthProperties.getSignUpRedirectUri() : googleOAuthProperties.getSignInRedirectUri();
+    }
+}

--- a/src/main/java/chzzk/grassdiary/domain/auth/client/OAuthClient.java
+++ b/src/main/java/chzzk/grassdiary/domain/auth/client/OAuthClient.java
@@ -1,0 +1,7 @@
+package chzzk.grassdiary.domain.auth.client;
+
+import chzzk.grassdiary.domain.auth.service.dto.GoogleOAuthToken;
+
+public interface OAuthClient {
+    GoogleOAuthToken getGoogleAccessToken(String code, boolean isSignUp);
+}

--- a/src/main/java/chzzk/grassdiary/domain/auth/config/GoogleOAuthProperties.java
+++ b/src/main/java/chzzk/grassdiary/domain/auth/config/GoogleOAuthProperties.java
@@ -31,4 +31,7 @@ public class GoogleOAuthProperties {
 
     @Value("${oauth2.client.provider.google.token-uri}")
     private String tokenUri;
+
+    @Value("${oauth2.client.provider.google.user-info-uri}")
+    private String userInfoUri;
 }

--- a/src/main/java/chzzk/grassdiary/domain/auth/config/GoogleOAuthProperties.java
+++ b/src/main/java/chzzk/grassdiary/domain/auth/config/GoogleOAuthProperties.java
@@ -1,0 +1,34 @@
+package chzzk.grassdiary.domain.auth.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Configuration
+public class GoogleOAuthProperties {
+
+    @Value("${oauth2.client.registration.google.client-id}")
+    private String clientId;
+
+    @Value("${oauth2.client.registration.google.client-secret}")
+    private String clientSecret;
+
+    @Value("${oauth2.client.registration.google.signin-redirect-uri}")
+    private String signInRedirectUri;
+
+    @Value("${oauth2.client.registration.google.signup-redirect-uri}")
+    private String signUpRedirectUri;
+
+    @Value("${oauth2.client.registration.google.authorization-grant-type}")
+    private String responseType;
+
+    @Value("${oauth2.client.registration.google.scope}")
+    private String scope;
+
+    @Value("${oauth2.client.provider.google.authorization-uri}")
+    private String authorizationUri;
+
+    @Value("${oauth2.client.provider.google.token-uri}")
+    private String tokenUri;
+}

--- a/src/main/java/chzzk/grassdiary/domain/auth/controller/OAuthSignInController.java
+++ b/src/main/java/chzzk/grassdiary/domain/auth/controller/OAuthSignInController.java
@@ -1,0 +1,29 @@
+package chzzk.grassdiary.domain.auth.controller;
+
+import chzzk.grassdiary.domain.auth.service.OAuthSignInService;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class OAuthSignInController {
+    private final OAuthSignInService oAuthSignInService;
+
+    @GetMapping("/api/signin/auth/google")
+    public void signInGoogle(HttpServletResponse response) throws IOException {
+        String redirectUri = oAuthSignInService.findSignInRedirectUri();
+
+        response.sendRedirect(redirectUri);
+    }
+
+    // todo
+    @GetMapping("/signin/auth/code/google")
+    public ResponseEntity<String> signInAuthorizeUser(@RequestParam("code") String code, HttpServletResponse response) {
+        return ResponseEntity.ok("callback"); // test
+    }
+}

--- a/src/main/java/chzzk/grassdiary/domain/auth/controller/OAuthSignUpController.java
+++ b/src/main/java/chzzk/grassdiary/domain/auth/controller/OAuthSignUpController.java
@@ -1,0 +1,29 @@
+package chzzk.grassdiary.domain.auth.controller;
+
+import chzzk.grassdiary.domain.auth.service.OAuthSignUpService;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class OAuthSignUpController {
+    private final OAuthSignUpService oAuthSignUpService;
+
+    @GetMapping("/api/signup/auth/google")
+    public void signUpGoogle(HttpServletResponse response) throws IOException {
+        String redirectUri = oAuthSignUpService.findSignUpRedirectUri();
+        response.sendRedirect(redirectUri);
+    }
+
+    // todo
+    @GetMapping("/signup/auth/code/google")
+    public void signUpAuthorizeUser(@RequestParam("code") String code, HttpServletResponse response)
+            throws IOException {
+        response.getWriter().write("callback");
+        //return ResponseEntity.ok("callback"); // test
+    }
+}

--- a/src/main/java/chzzk/grassdiary/domain/auth/service/OAuthSignInService.java
+++ b/src/main/java/chzzk/grassdiary/domain/auth/service/OAuthSignInService.java
@@ -1,0 +1,15 @@
+package chzzk.grassdiary.domain.auth.service;
+
+import chzzk.grassdiary.domain.auth.util.GoogleOAuthUriGenerator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthSignInService {
+    private final GoogleOAuthUriGenerator googleOAuthUriGenerator;
+
+    public String findSignInRedirectUri() {
+        return googleOAuthUriGenerator.generateSignInUrl();
+    }
+}

--- a/src/main/java/chzzk/grassdiary/domain/auth/service/OAuthSignUpService.java
+++ b/src/main/java/chzzk/grassdiary/domain/auth/service/OAuthSignUpService.java
@@ -1,0 +1,20 @@
+package chzzk.grassdiary.domain.auth.service;
+
+import chzzk.grassdiary.domain.auth.util.GoogleOAuthUriGenerator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthSignUpService {
+
+    private final GoogleOAuthUriGenerator googleOAuthUriGenerator;
+
+    /**
+     * 사용자가 로그인 완료 및 권한 승인을 하면, 인증 서버는 클라이언트가 지정한 redirect_uri로 사용자를 리디렉트한다
+     * <p>
+     */
+    public String findSignUpRedirectUri() {
+        return googleOAuthUriGenerator.generateSignUpUrl();
+    }
+}

--- a/src/main/java/chzzk/grassdiary/domain/auth/service/dto/GoogleOAuthToken.java
+++ b/src/main/java/chzzk/grassdiary/domain/auth/service/dto/GoogleOAuthToken.java
@@ -1,0 +1,14 @@
+package chzzk.grassdiary.domain.auth.service.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+
+@Getter
+// JSON 직렬화(object -> JSON) 및 역직렬화(JSON -> object) 시 사용되는 네이밍 전략 설정 어노테이션
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record GoogleOAuthToken(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/chzzk/grassdiary/domain/auth/util/GoogleOAuthUriGenerator.java
+++ b/src/main/java/chzzk/grassdiary/domain/auth/util/GoogleOAuthUriGenerator.java
@@ -1,0 +1,39 @@
+package chzzk.grassdiary.domain.auth.util;
+
+import chzzk.grassdiary.domain.auth.config.GoogleOAuthProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GoogleOAuthUriGenerator implements OAuthUriGenerator {
+
+    private final GoogleOAuthProperties googleOAuthProperties;
+
+    /**
+     * @return Google 인증서버에 대한 인가코드 요청 URI
+     */
+    @Override
+    public String generateSignUpUrl() {
+        return String.format(
+                "%s?client_id=%s&redirect_uri=%s&response_type=%s&scope=%s",
+                googleOAuthProperties.getAuthorizationUri(),
+                googleOAuthProperties.getClientId(),
+                googleOAuthProperties.getSignUpRedirectUri(),
+                googleOAuthProperties.getResponseType(),
+                googleOAuthProperties.getScope()
+        );
+    }
+
+    @Override
+    public String generateSignInUrl() {
+        return String.format(
+                "%s?client_id=%s&redirect_uri=%s&response_type=%s&scope=%s",
+                googleOAuthProperties.getAuthorizationUri(),
+                googleOAuthProperties.getClientId(),
+                googleOAuthProperties.getSignInRedirectUri(),
+                googleOAuthProperties.getResponseType(),
+                googleOAuthProperties.getScope()
+        );
+    }
+}

--- a/src/main/java/chzzk/grassdiary/domain/auth/util/OAuthUriGenerator.java
+++ b/src/main/java/chzzk/grassdiary/domain/auth/util/OAuthUriGenerator.java
@@ -1,0 +1,8 @@
+package chzzk.grassdiary.domain.auth.util;
+
+
+public interface OAuthUriGenerator {
+    String generateSignUpUrl();
+
+    String generateSignInUrl();
+}

--- a/src/main/java/chzzk/grassdiary/domain/member/Member.java
+++ b/src/main/java/chzzk/grassdiary/domain/member/Member.java
@@ -10,6 +10,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -17,20 +24,32 @@ import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @Setter // DBTest에서 임시 사용
-@NoArgsConstructor
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Entity
+@Table(uniqueConstraints = {
+        @UniqueConstraint(
+                name = "NICKNAME_EMAIL_UNIQUE",
+                columnNames = {"nickname", "email"}
+        )}
+) // 닉네임, 이메일 중복 금지
 public class Member extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")
     private Long id;
 
-    private String nickname;
+    @Column(nullable = false)
+    @Size(min = 1, max = 20)
+    private String nickname;  // auth
 
-    private String email;
+    @Column(nullable = false, length = 200)
+    @Email(message = "유효하지 않은 이메일 주소입니다.")
+    private String email; // auth
 
     @Lob
-    private String profileImageUrl;
+    private String profileImageUrl; // auth
 
     private Long grassCount;
 


### PR DESCRIPTION
## 🔥 진행상황 공유를 위해 PR 올립니다. 참고 부탁드립니다.


완료           | 기능                                 |      상세 설명 | API | URL 
-------------| -----------------------------| ----- | --------| --------|
✅ | 구글 회원가입 | 회원가입 버튼을 누르면 구글 로그인 페이지를 띄운다.  | GET | /api/signup/auth/google 
❌ | 구글 회원가입 | 회원인 경우 "이미 가입된 회원입니다." 응답을 보내고, 회원이 아닌 경우 회원 가입을 완료한다.|  | |
✅ | 구글 로그인 | 로그인 버튼을 누르면 구글 로그인 페이지를 띄운다.  | GET | /api/signin/auth/google 
❌ | 구글 로그인 | 회원인 경우 로그인을 진행하고, 회원이 아닌 경우 "가입되지 않은 회원입니다." 응답을 보낸다.  |  | |


<br>

---

## 💡백엔드에서 기능을 구현하는 이유

⭐️ 소셜 회원가입 및 로그인 기능 구현을 할 때, 백엔드에서 해당 기능을 모두 구현하려고 합니다.

`프론트에서 기능 구현(v1), 프론트/백엔드 나누어 기능 구현(v2), 백엔드에서 기능 구현(v3)` 총 3가지 방법이 있습니다.

v2 방식은 카카오와 같은 대형 서비스 개발 포럼 및 보안 규격에서는 해당 방식을 지양하고 있으며, 간단한 토이 프로젝트용으로 사용하는 방식이므로 제외했습니다. 
v1 방식은 해당 API로 다른 사용자가 다른 사용자의 정보를 보내도 사용자를 생성할 수 있어 추가적인 보안 로직 및 터널링 작업이 필요하므로 제외했습니다.

따라서, 프론트단에서 백엔드의 로그인 경로로 하이퍼링킹을 진행한 후, 백엔드단에서 `로그인 페이지 요청 -> 인가 코드 발급 -> Access Token -> 사용자 정보 획득 -> JWT 발급` 방식을 사용하고자 합니다.  (주로 웹앱/모바일앱 통합 환경 서버에서 사용하는 방식입니다.)

<br>

## 🌱 참고 사항

Spring Security, OAuth dependency를 사용하지 않고 설정 정보를 커스텀하여 사용하고자 합니다.
