### PR TITLE
feat(todayQuestion): 오늘의 질문 하루 1개씩 랜덤, DB에 데이터 저장

### DIFF
--- a/src/main/java/chzzk/grassdiary/GrassdiaryApplication.java
+++ b/src/main/java/chzzk/grassdiary/GrassdiaryApplication.java
@@ -3,7 +3,9 @@ package chzzk.grassdiary;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class GrassdiaryApplication {

--- a/src/main/java/chzzk/grassdiary/domain/diary/question/QuestionPrompt.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/question/QuestionPrompt.java
@@ -41,10 +41,14 @@ public enum QuestionPrompt {
         this.question = question;
     }
 
-    public static String getRandomQuestion() {
+    public static QuestionPrompt getRandomQuestion() {
         random.setSeed(System.currentTimeMillis());
         QuestionPrompt[] prompt = values();
 
-        return prompt[random.nextInt(prompt.length)].question;
+        return prompt[random.nextInt(prompt.length)];
+    }
+
+    public String getQuestion() {
+        return question;
     }
 }

--- a/src/main/java/chzzk/grassdiary/domain/diary/question/TodayQuestion.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/question/TodayQuestion.java
@@ -1,0 +1,25 @@
+package chzzk.grassdiary.domain.diary.question;
+
+import chzzk.grassdiary.domain.base.BaseCreatedTimeEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class TodayQuestion extends BaseCreatedTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "today_question_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private QuestionPrompt questionPrompt;
+
+    @Builder
+    public TodayQuestion(QuestionPrompt questionPrompt) {
+        this.questionPrompt = questionPrompt;
+    }
+}

--- a/src/main/java/chzzk/grassdiary/domain/diary/question/TodayQuestionRepository.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/question/TodayQuestionRepository.java
@@ -1,0 +1,11 @@
+package chzzk.grassdiary.domain.diary.question;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
+
+public interface TodayQuestionRepository extends JpaRepository<TodayQuestion, Long> {
+    @Query("SELECT t FROM TodayQuestion t WHERE t.createdAt >= :startOfDay AND t.createdAt <= :endOfDay")
+    TodayQuestion findByCreatedAtBetween(LocalDateTime startOfDay, LocalDateTime endOfDay);
+}

--- a/src/main/java/chzzk/grassdiary/service/MainService.java
+++ b/src/main/java/chzzk/grassdiary/service/MainService.java
@@ -2,6 +2,7 @@ package chzzk.grassdiary.service;
 
 import static chzzk.grassdiary.domain.diary.question.QuestionPrompt.getRandomQuestion;
 
+import chzzk.grassdiary.domain.diary.question.QuestionPrompt;
 import chzzk.grassdiary.web.dto.main.TodayInfoDTO;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -17,8 +18,8 @@ public class MainService {
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("오늘은 M월 d일입니다.");
         String todayDate = today.format(dateTimeFormatter);
 
-        String todayQuestion = getRandomQuestion();
+        QuestionPrompt todayQuestion = getRandomQuestion();
 
-        return new TodayInfoDTO(todayDate, todayQuestion);
+        return new TodayInfoDTO(todayDate, "fix");
     }
 }

--- a/src/main/java/chzzk/grassdiary/service/diary/TodayQuestionService.java
+++ b/src/main/java/chzzk/grassdiary/service/diary/TodayQuestionService.java
@@ -1,0 +1,42 @@
+package chzzk.grassdiary.service.diary;
+
+import chzzk.grassdiary.domain.diary.question.TodayQuestion;
+import chzzk.grassdiary.domain.diary.question.TodayQuestionRepository;
+import chzzk.grassdiary.web.dto.main.TodayInfoDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+import static chzzk.grassdiary.domain.diary.question.QuestionPrompt.getRandomQuestion;
+
+@RequiredArgsConstructor
+@Service
+public class TodayQuestionService {
+
+    private final TodayQuestionRepository todayQuestionRepository;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void makeTodayQuestions() {
+        todayQuestionRepository.save(new TodayQuestion(getRandomQuestion()));
+    }
+
+    @Transactional(readOnly = true)
+    public TodayInfoDTO getTodayQuestion() {
+        LocalDate today = LocalDate.now();
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("오늘은 M월 d일입니다.");
+        String todayDate = today.format(dateTimeFormatter);
+
+        LocalDateTime startOfDay = today.atStartOfDay();
+        LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
+
+        TodayQuestion todayQuestion = todayQuestionRepository.findByCreatedAtBetween(startOfDay, endOfDay);
+
+        return new TodayInfoDTO(todayDate, todayQuestion.getQuestionPrompt().getQuestion());
+    }
+}

--- a/src/main/java/chzzk/grassdiary/web/controller/DiaryController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/DiaryController.java
@@ -3,6 +3,7 @@ package chzzk.grassdiary.web.controller;
 import chzzk.grassdiary.auth.common.AuthenticatedMember;
 import chzzk.grassdiary.auth.service.dto.AuthMemberPayload;
 import chzzk.grassdiary.service.diary.DiaryService;
+import chzzk.grassdiary.service.diary.TodayQuestionService;
 import chzzk.grassdiary.web.dto.diary.DiaryDTO;
 import chzzk.grassdiary.web.dto.diary.DiaryResponseDTO;
 import chzzk.grassdiary.web.dto.diary.DiarySaveRequestDTO;
@@ -32,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "일기 컨트롤러")
 public class DiaryController {
     private final DiaryService diaryService;
+    private final TodayQuestionService todayQuestionService;
 
     @PostMapping("/{memberId}")
     public Long save(@PathVariable(name = "memberId") Long memberId, @RequestBody DiarySaveRequestDTO requestDto) {
@@ -73,7 +75,7 @@ public class DiaryController {
         return ResponseEntity.ok(diaryService.findAll(pageable, memberId));
     }
 
-    // 로그인 공부 후 memberId 부분을 auth로? 대체할 수 있는지 알아보기
+    // todo: 로그인 공부 후 memberId 부분을 auth로? 대체할 수 있는지 알아보기
     @PostMapping("/like/{diaryId}/{memberId}")
     public Long addLike(@PathVariable("diaryId") Long diaryId, @PathVariable("memberId") Long memberId) {
         return diaryService.addLike(diaryId, memberId);
@@ -82,5 +84,14 @@ public class DiaryController {
     @DeleteMapping("/like/{diaryId}/{memberId}")
     public Long deleteLike(@PathVariable("diaryId") Long diaryId, @PathVariable("memberId") Long memberId) {
         return diaryService.deleteLike(diaryId, memberId);
+    }
+
+    @GetMapping("/todayQuestion")
+    @Operation(
+            summary = "오늘의 질문을 반환",
+            description = "매일 12시에 업데이트"
+    )
+    public ResponseEntity<?> findTodayQuestion() {
+        return ResponseEntity.ok(todayQuestionService.getTodayQuestion());
     }
 }


### PR DESCRIPTION
오늘의 질문 하루 1개씩(24시 기준) 새로운 질문으로 update가 이뤄짐

<추후 수정>
-> 프론트에서 체크박스를 사용하여 오늘의 질문에 대한 대답이라면 텍스트 앞 부분에 오늘의 질문을 붙여서 전송하고, 해시태그에도 '오늘의질문' 추가하는 것으로 결정
-> 그렇다면 DB에 저장 하지 않고 전송만 해주어도 동작 할 것임...