### PR TITLE
fix : diary API 클라이언트 오류시 기존 500 -> 400 에러로 코드 수정

### DIFF
--- a/src/main/java/chzzk/grassdiary/web/controller/DiaryController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/DiaryController.java
@@ -7,6 +7,11 @@ import chzzk.grassdiary.web.dto.diary.DiaryDTO;
 import chzzk.grassdiary.web.dto.diary.DiaryResponseDTO;
 import chzzk.grassdiary.web.dto.diary.DiarySaveRequestDTO;
 import chzzk.grassdiary.web.dto.diary.DiaryUpdateRequestDTO;
+import chzzk.grassdiary.web.exceptions.AlreadyLikedException;
+import chzzk.grassdiary.web.exceptions.DiaryNotFoundException;
+import chzzk.grassdiary.web.exceptions.ErrorObject;
+import chzzk.grassdiary.web.exceptions.MemberNotFoundException;
+import chzzk.grassdiary.web.exceptions.NotLikedException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -16,8 +21,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -83,4 +90,30 @@ public class DiaryController {
     public Long deleteLike(@PathVariable("diaryId") Long diaryId, @PathVariable("memberId") Long memberId) {
         return diaryService.deleteLike(diaryId, memberId);
     }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorObject> handleException(MemberNotFoundException ex) {
+        ErrorObject errorObject = new ErrorObject(HttpStatus.NOT_FOUND.value(), ex.getMessage());
+        return new ResponseEntity<>(errorObject, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorObject> handleException(DiaryNotFoundException ex) {
+        ErrorObject errorObject = new ErrorObject(HttpStatus.NOT_FOUND.value(), ex.getMessage());
+        return new ResponseEntity<>(errorObject, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorObject> handleException(AlreadyLikedException ex) {
+        ErrorObject errorObject = new ErrorObject(HttpStatus.NOT_FOUND.value(), ex.getMessage());
+        return new ResponseEntity<>(errorObject, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorObject> handleException(NotLikedException ex) {
+        ErrorObject errorObject = new ErrorObject(HttpStatus.NOT_FOUND.value(), ex.getMessage());
+        return new ResponseEntity<>(errorObject, HttpStatus.NOT_FOUND);
+    }
+
+
 }

--- a/src/main/java/chzzk/grassdiary/web/exceptions/AlreadyLikedException.java
+++ b/src/main/java/chzzk/grassdiary/web/exceptions/AlreadyLikedException.java
@@ -1,0 +1,18 @@
+package chzzk.grassdiary.web.exceptions;
+
+public class AlreadyLikedException extends RuntimeException {
+    public AlreadyLikedException() {
+    }
+
+    public AlreadyLikedException(String message) {
+        super(message);
+    }
+
+    public AlreadyLikedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public AlreadyLikedException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/chzzk/grassdiary/web/exceptions/DiaryNotFoundException.java
+++ b/src/main/java/chzzk/grassdiary/web/exceptions/DiaryNotFoundException.java
@@ -1,0 +1,19 @@
+package chzzk.grassdiary.web.exceptions;
+
+public class DiaryNotFoundException extends RuntimeException {
+    public DiaryNotFoundException() {
+        super();
+    }
+
+    public DiaryNotFoundException(String message) {
+        super(message);
+    }
+
+    public DiaryNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public DiaryNotFoundException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/chzzk/grassdiary/web/exceptions/ErrorObject.java
+++ b/src/main/java/chzzk/grassdiary/web/exceptions/ErrorObject.java
@@ -1,0 +1,15 @@
+package chzzk.grassdiary.web.exceptions;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorObject {
+    private int status;
+
+    private String message;
+
+    public ErrorObject(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/chzzk/grassdiary/web/exceptions/MemberNotFoundException.java
+++ b/src/main/java/chzzk/grassdiary/web/exceptions/MemberNotFoundException.java
@@ -1,0 +1,19 @@
+package chzzk.grassdiary.web.exceptions;
+
+public class MemberNotFoundException extends RuntimeException {
+    public MemberNotFoundException() {
+        super();
+    }
+
+    public MemberNotFoundException(String message) {
+        super(message);
+    }
+
+    public MemberNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public MemberNotFoundException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/chzzk/grassdiary/web/exceptions/NotLikedException.java
+++ b/src/main/java/chzzk/grassdiary/web/exceptions/NotLikedException.java
@@ -1,0 +1,18 @@
+package chzzk.grassdiary.web.exceptions;
+
+public class NotLikedException extends RuntimeException {
+    public NotLikedException() {
+    }
+
+    public NotLikedException(String message) {
+        super(message);
+    }
+
+    public NotLikedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NotLikedException(Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
AlreadyLikedException
NotLikedException
DiaryNotFoundException
MemberNotFoundException

적용 하였으며, db에 저장되었는지 확인할 때 쓰인 부분은 추가로 공부하고 적용하기 위해서 빼놓았습니다!

* 추가로 controller단에서 execption관련 코드를 나열하지 않을 수 있도록 더 깔끔한 코드에 대해서 찾아보고 공부하고 있습니다. 이후 수정해보겠습니다.