### PR TITLE
Like_count가 수정될 때 updated_at도 수정되는 부분 해결하기

### DIFF
--- a/src/main/java/chzzk/grassdiary/domain/diary/Diary.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/Diary.java
@@ -56,9 +56,6 @@ public class Diary extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private ConditionLevel conditionLevel;
 
-    @ColumnDefault("0")
-    private int likeCount;
-
     @Builder
     protected Diary(Member member, String content, Boolean isPrivate, Boolean hasImage,
                     Boolean hasTag, ConditionLevel conditionLevel) {
@@ -69,7 +66,6 @@ public class Diary extends BaseTimeEntity {
         this.hasTag = hasTag;
         this.conditionLevel = conditionLevel;
         this.setCreatedAt(LocalDateTime.now());
-        this.likeCount = 0;
     }
 
     public void update(String content, Boolean isPrivate, Boolean hasImage, Boolean hasTag,
@@ -79,25 +75,5 @@ public class Diary extends BaseTimeEntity {
         this.hasImage = hasImage;
         this.hasTag = hasTag;
         this.conditionLevel = conditionLevel;
-    }
-
-    public void addDiaryLike(DiaryLike diaryLike) {
-        diaryLikes.add(diaryLike);
-        diaryLike.setDiary(this);
-        incrementLikeCount();
-    }
-
-    public void deleteDiaryLike(DiaryLike diaryLike) {
-        diaryLikes.removeIf(dl -> dl.getId().equals(diaryLike.getId()));
-//        diaryLike.setDiary(null);
-        decrementLikeCount();
-    }
-
-    public void incrementLikeCount() {
-        this.likeCount += 1;
-    }
-
-    public void decrementLikeCount() {
-        this.likeCount -= 1;
     }
 }

--- a/src/main/java/chzzk/grassdiary/domain/diary/DiaryLike.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/DiaryLike.java
@@ -38,8 +38,7 @@ public class DiaryLike extends BaseCreatedTimeEntity {
     private Diary diary;
 
     @Builder
-    public DiaryLike(Long id, Member member, Diary diary) {
-        this.id = id;
+    public DiaryLike(Member member, Diary diary) {
         this.member = member;
         this.diary = diary;
     }

--- a/src/main/java/chzzk/grassdiary/domain/diary/DiaryRepository.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/DiaryRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
     Page<Diary> findDiaryByMemberId(Long memberId, Pageable pageable);
@@ -21,9 +22,10 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     @Query("SELECT d FROM Diary d WHERE d.isPrivate = false"
             + " AND d.createdAt >= :startOfWeek AND d.createdAt <= :endOfWeek"
-            + " ORDER BY d.likeCount DESC, d.createdAt ASC")
-    Page<Diary> findTop10DiariesThisWeek(LocalDateTime startOfWeek, LocalDateTime endOfWeek, PageRequest pageRequest);
-    
+            + " ORDER BY SIZE(d.diaryLikes) DESC, d.createdAt ASC")
+    Page<Diary> findTop10DiariesThisWeek(@Param("startOfWeek") LocalDateTime startOfWeek,
+                                         @Param("endOfWeek") LocalDateTime endOfWeek, PageRequest pageRequest);
+
     @Query("SELECT d FROM Diary d WHERE d.isPrivate = false"
             + " AND d.id < :cursorId"
             + " ORDER BY d.createdAt DESC, d.id DESC")

--- a/src/main/java/chzzk/grassdiary/service/diary/DiaryService.java
+++ b/src/main/java/chzzk/grassdiary/service/diary/DiaryService.java
@@ -292,10 +292,10 @@ public class DiaryService {
                 });
 
         DiaryLike diaryLike = DiaryLike.builder()
+                .diary(diary)
                 .member(member)
                 .build();
 
-        diary.addDiaryLike(diaryLike);
         diaryLikeRepository.save(diaryLike);
 
         // 추후 DTO로 return값 변경
@@ -310,7 +310,6 @@ public class DiaryService {
         DiaryLike diaryLike = diaryLikeRepository.findByDiaryIdAndMemberId(diaryId, memberId)
                 .orElseThrow(() -> new NotLikedException("해당 게시글에 좋아요를 누르지 않았습니다."));
 
-        diary.deleteDiaryLike(diaryLike);
         diaryLikeRepository.delete(diaryLike);
 
         // 추후 DTO로 return값 변경

--- a/src/main/java/chzzk/grassdiary/web/controller/DiaryController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/DiaryController.java
@@ -114,6 +114,4 @@ public class DiaryController {
         ErrorObject errorObject = new ErrorObject(HttpStatus.NOT_FOUND.value(), ex.getMessage());
         return new ResponseEntity<>(errorObject, HttpStatus.NOT_FOUND);
     }
-
-
 }

--- a/src/main/java/chzzk/grassdiary/web/dto/diary/DiaryResponseDTO.java
+++ b/src/main/java/chzzk/grassdiary/web/dto/diary/DiaryResponseDTO.java
@@ -32,7 +32,7 @@ public class DiaryResponseDTO {
         this.createdAt = diary.getCreatedAt().format(DateTimeFormatter.ofPattern("HH:mm"));
         this.tags = tags;
         this.transparency = diary.getConditionLevel().getTransparency();
-        this.likeCount = diary.getLikeCount();
+        this.likeCount = diary.getDiaryLikes().size();
         this.isLikedByLogInMember = isLikedByLogInMember;
     }
 }

--- a/src/main/java/chzzk/grassdiary/web/dto/share/LatestDiaryDto.java
+++ b/src/main/java/chzzk/grassdiary/web/dto/share/LatestDiaryDto.java
@@ -22,7 +22,7 @@ public record LatestDiaryDto(
         return new LatestDiaryDto(
                 diary.getId(),
                 diary.getContent(),
-                diary.getLikeCount(),
+                diary.getDiaryLikes().size(),
                 diary.getMember().getId(),
                 diary.getMember().getNickname(),
                 diary.getCreatedAt()

--- a/src/main/java/chzzk/grassdiary/web/dto/share/Top10DiariesDto.java
+++ b/src/main/java/chzzk/grassdiary/web/dto/share/Top10DiariesDto.java
@@ -18,7 +18,7 @@ public record Top10DiariesDto(
                 .map(d -> new Top10DiariesDto(
                         d.getId(),
                         d.getContent(),
-                        d.getLikeCount(),
+                        d.getDiaryLikes().size(),
                         d.getMember().getId(),
                         d.getMember().getNickname(),
                         d.getCreatedAt()


### PR DESCRIPTION
```java
@Getter
@MappedSuperclass
@EntityListeners(AuditingEntityListener.class)
public class BaseTimeEntity extends BaseCreatedTimeEntity {
    @LastModifiedDate
    private LocalDateTime updatedAt;
}

```
```java
@Getter
@Setter
@NoArgsConstructor(access = AccessLevel.PROTECTED)
@Entity
public class Diary extends BaseTimeEntity {
    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    @Column(name = "diary_id")
    private Long id;

    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "member_id")
    private Member member;

    @Column(columnDefinition = "TEXT")
    private String content;

    @ColumnDefault("true")
    private Boolean isPrivate;

    @OneToMany(mappedBy = "diary")
    private List<DiaryLike> diaryLikes = new ArrayList<>();

    @ColumnDefault("false")
    private Boolean hasImage;

    @ColumnDefault("false")
    private Boolean hasTag;

    @Enumerated(EnumType.STRING)
    private ConditionLevel conditionLevel;

    @ColumnDefault("0")
    private int likeCount;

    @Builder
    protected Diary(Member member, String content, Boolean isPrivate, Boolean hasImage,
                    Boolean hasTag, ConditionLevel conditionLevel) {
        this.member = member;
        this.content = content;
        this.isPrivate = isPrivate;
        this.hasImage = hasImage;
        this.hasTag = hasTag;
        this.conditionLevel = conditionLevel;
        this.setCreatedAt(LocalDateTime.now());
        this.likeCount = 0;
    }

    public void update(String content, Boolean isPrivate, Boolean hasImage, Boolean hasTag,
                       ConditionLevel conditionLevel) {
        this.content = content;
        this.isPrivate = isPrivate;
        this.hasImage = hasImage;
        this.hasTag = hasTag;
        this.conditionLevel = conditionLevel;
    }

    public void addDiaryLike(DiaryLike diaryLike) {
        diaryLikes.add(diaryLike);
        diaryLike.setDiary(this);
        incrementLikeCount();
    }

    public void deleteDiaryLike(DiaryLike diaryLike) {
        diaryLikes.removeIf(dl -> dl.getId().equals(diaryLike.getId()));
//        diaryLike.setDiary(null);
        decrementLikeCount();
    }

    public void incrementLikeCount() {
        this.likeCount += 1;
    }

    public void decrementLikeCount() {
        this.likeCount -= 1;
    }
}

```


@LastModifiedDate 어노테이션이 붙은 updatedAt 필드는 JPA의 Auditing 기능을 이용해서 엔티티의 어떤 필드라도 변경이 일어났을 때 자동으로 업데이트 시간을 현재 시간으로 변경해 줍니다. 이는 보통 데이터의 일관성과 역추적을 위해 매우 유용하지만, 특정 필드(예: likeCount)의 변경을 추적 대상에서 제외하고 싶은 경우에는 문제가 될 수 있습니다.
이를 해결하기 위해서 3가지 방법이 있습니다.
1. @LastModifiedDate를 사용하지 않고 변경된 필드만 데이터베이스에 업데이트하는 @DynamicUpdate 사용하기
- 그러나 @DynamicUpadate를 사용하면 updatedAt 필드의 주요 목적인 항상 최신 변경사항을 반영하는 것을 완벽하게 보장하지 않는다는 단점이 생깁니다.
2. likeCount를 다른 entity로 분리하기
- 이 방법을 사용할 경우 likeCount를 처리하기 위해 추가적인 클래스와 데이터베이스 테이블이 필요하다는 단점이 생깁니다.
3. likeCount 삭제하기
- 이 방법을 사용할 경우 좋아요 개수를 세기 위해 diaryLike entity를 뒤져야해 속도가 약간 느려지는 단점이 생깁니다. 

그러나 이미 양방향 연결관계가 설정되어있는점, 이를 활용하면 적은 양의 코드 변경을 통해 오류를 수정할 수 있는 점, 유저가 아직 별로 없는 저희 서비스를 고려했을 때 3번 방법이 적절하다고 생각해 likeCount를 삭제하려고 합니다.

-> likeCount를 삭제하고 diaryLikes를 활용해서 좋아요 개수를 세도록 코드를 변경했습니다.