### PR TITLE
[feat/make-s3-server] 이미지 저장용 AWS S3 서버 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
 
     annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
@@ -43,6 +44,10 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+
+    // aws s3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation group: 'org.apache.tika', name: 'tika-parsers', version: '1.25'
 }
 
 compileJava {

--- a/src/main/java/chzzk/grassdiary/GrassdiaryApplication.java
+++ b/src/main/java/chzzk/grassdiary/GrassdiaryApplication.java
@@ -1,13 +1,16 @@
 package chzzk.grassdiary;
 
+import chzzk.grassdiary.storage.AwsProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
+@EnableConfigurationProperties(value = {AwsProperties.class})
 public class GrassdiaryApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/chzzk/grassdiary/exception/file/IllegalMimeTypeException.java
+++ b/src/main/java/chzzk/grassdiary/exception/file/IllegalMimeTypeException.java
@@ -1,0 +1,4 @@
+package chzzk.grassdiary.exception.file;
+
+public class IllegalMimeTypeException extends RuntimeException {
+}

--- a/src/main/java/chzzk/grassdiary/exception/file/ImageRoadFailedException.java
+++ b/src/main/java/chzzk/grassdiary/exception/file/ImageRoadFailedException.java
@@ -1,0 +1,4 @@
+package chzzk.grassdiary.exception.file;
+
+public class ImageRoadFailedException extends RuntimeException {
+}

--- a/src/main/java/chzzk/grassdiary/storage/AwsProperties.java
+++ b/src/main/java/chzzk/grassdiary/storage/AwsProperties.java
@@ -1,0 +1,50 @@
+package chzzk.grassdiary.storage;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "cloud.aws")
+public class AwsProperties {
+    private final Credentials credentials = new Credentials();
+    private final S3 s3 = new S3();
+    private final Region region = new Region();
+
+    @Getter
+    @Setter
+    public static class Credentials {
+        private String accessKey;
+        private String secretKey;
+    }
+
+    @Getter
+    @Setter
+    public static class S3 {
+        private String bucket;
+    }
+
+    @Getter
+    @Setter
+    public static class Region {
+        private String statics;
+    }
+
+    public String getAccessKey() {
+        return credentials.getAccessKey();
+    }
+
+    public String getSecretKey() {
+        return credentials.getSecretKey();
+    }
+
+    public String getBucket() {
+        return s3.getBucket();
+    }
+
+    public String getRegionStatic() {
+        return region.getStatics();
+    }
+}

--- a/src/main/java/chzzk/grassdiary/storage/AwsS3Service.java
+++ b/src/main/java/chzzk/grassdiary/storage/AwsS3Service.java
@@ -1,0 +1,68 @@
+package chzzk.grassdiary.storage;
+
+import chzzk.grassdiary.exception.file.ImageRoadFailedException;
+import chzzk.grassdiary.utils.file.FileNameUtils;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.apache.tika.Tika;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Service
+public class AwsS3Service implements StorageService {
+    private final AwsProperties awsProperties;
+    private AmazonS3 s3Client;
+
+    @PostConstruct
+    private void setS3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(
+                awsProperties.getAccessKey(), awsProperties.getSecretKey()
+        );
+
+        s3Client = AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(awsProperties.getRegionStatic())
+                .build();
+    }
+
+    public String uploadBucket(MultipartFile file) {
+        return upload(file, awsProperties.getBucket());
+    }
+
+    @Override
+    public String upload(MultipartFile file, String bucket) {
+        String fileName = file.getOriginalFilename();
+        String convertedFileName = FileNameUtils.fileNameConvert(fileName);
+
+        try {
+            String mimeType = new Tika().detect(file.getInputStream());
+            ObjectMetadata metadata = new ObjectMetadata();
+
+            FileNameUtils.checkImageMimeType(mimeType);
+            metadata.setContentType(mimeType);
+            s3Client.putObject(
+                    new PutObjectRequest(
+                            bucket,
+                            convertedFileName,
+                            file.getInputStream(), metadata
+                    )
+                            .withCannedAcl(CannedAccessControlList.PublicRead)
+            );
+        } catch (IOException e) {
+            throw new ImageRoadFailedException();
+        }
+
+        return s3Client.getUrl(bucket, convertedFileName).toString();
+    }
+}

--- a/src/main/java/chzzk/grassdiary/storage/StorageService.java
+++ b/src/main/java/chzzk/grassdiary/storage/StorageService.java
@@ -1,0 +1,7 @@
+package chzzk.grassdiary.storage;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface StorageService {
+    String upload(MultipartFile file, String destLocation);
+}

--- a/src/main/java/chzzk/grassdiary/storage/test/ImageTestService.java
+++ b/src/main/java/chzzk/grassdiary/storage/test/ImageTestService.java
@@ -1,0 +1,22 @@
+package chzzk.grassdiary.storage.test;
+
+import chzzk.grassdiary.storage.AwsS3Service;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ImageTestService {
+
+    private final AwsS3Service awsS3Service;
+
+    public void uploadImage(MultipartFile testFile) {
+        if (!testFile.isEmpty()) {
+            String s3FilePath = awsS3Service.uploadBucket(testFile);
+            // 이후에 이미지 url을 db에 저장해줘야함.
+        }
+    }
+}

--- a/src/main/java/chzzk/grassdiary/utils/file/FileNameUtils.java
+++ b/src/main/java/chzzk/grassdiary/utils/file/FileNameUtils.java
@@ -1,0 +1,30 @@
+package chzzk.grassdiary.utils.file;
+
+import chzzk.grassdiary.exception.file.IllegalMimeTypeException;
+
+import java.util.UUID;
+
+public class FileNameUtils {
+    public static void checkImageMimeType(String mimeType) {
+        if (!(mimeType.equals("image/jpg") || mimeType.equals("image/jpeg")
+                || mimeType.equals("image/png") || mimeType.equals("image/gif"))) {
+            throw new IllegalMimeTypeException();
+        }
+    }
+
+    public static String fileNameConvert(String fileName) {
+        StringBuilder builder = new StringBuilder();
+        UUID uuid = UUID.randomUUID();
+        String extension = getExtension(fileName);
+
+        builder.append(uuid).append(".").append(extension);
+
+        return builder.toString();
+    }
+
+    private static String getExtension(String fileName) {
+        int pos = fileName.lastIndexOf(".");
+
+        return fileName.substring(pos + 1);
+    }
+}

--- a/src/main/java/chzzk/grassdiary/web/controller/test/StorageTestController.java
+++ b/src/main/java/chzzk/grassdiary/web/controller/test/StorageTestController.java
@@ -1,0 +1,20 @@
+package chzzk.grassdiary.web.controller.test;
+
+import chzzk.grassdiary.storage.test.ImageTestService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/test/storage")
+public class StorageTestController {
+    private final ImageTestService imageTestService;
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    public void uploadImage(@RequestParam("file") MultipartFile testImage) {
+        imageTestService.uploadImage(testImage);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,3 +22,11 @@ oauth2.client.provider.google.user-info-uri=https://www.googleapis.com/oauth2/v1
 jwt.access.secret-key=${JWT_ACCESS_SECRET_KEY}
 jwt.access.expiration=1800000
 client.login-success-redirect-uri=https://grassdiary.site/main
+
+# aws-s3-config
+cloud.aws.credentials.accessKey=${S3_ACCESS_PUBLIC_KEY}
+cloud.aws.credentials.secretKey=${S3_ACCESS_SECRET_KEY}
+cloud.aws.s3.bucket=${S3_BUCKET_NAME}
+cloud.aws.region.static=ap-northeast-2
+cloud.aws.region.statics=ap-northeast-2
+cloud.aws.stack.auto=false


### PR DESCRIPTION
*서버 실행 전 `.env` 파일에 S3 버킷 관련 설정 추가 해주어야 합니다!

## AWS S3을 사용하는 방법

### 1. AWS S3 사용하기 위한 의존성 추가
``` gradle
//aws s3
implementation('org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE')
```

### 2. `AwsProperties` 객체 만들기
   - AWS S3를 사용하려면 설정 값을 주입하는 객체로 사용하는 클래스
   - OAuth를 만들 때는 `@Value`를 사용하여 주입 해주었으나 해당 방법은 불변이 아닌 데다, 타입 안정성이 보장되지 않는 문제가 있다고 한다.
   - 물론 `@ConfigurationProperties`를 사용하는 방식도 불변도 아니고 Setter가 공개되어 있어 값이 변경 될 수도 있다. 하지만 `@ConstructorBinding`과 함께 활용한다면 final 필드에 대해 값을 주입해주기 때문에 불변성을 보장하고 Setter 없이 값을 매칭할 수 있다.
   - `@ConfigurationProperties`와 `@ConstructorBinding`을 함께 사용하기 위해서는 ...
     1. `@ConfigurationProperties` 사용을 위한 의존성 추가
         ``` gradle
             annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
           ```
     2. `@ConfigurationProperties` 사용을 하는 클래스인 `AwsProperties`는 자동으로 Spring bean을 생성해주지 않기 때문에 `@EnableConfigurationProperties`를 사용하여 생성할 Properties 클래스의 클래스 타입을 명시해줘야 한다.
     3. `AwsProperties` 값 중 `static`이 Java 내부의 예약어이기 때문에 변수명을 `statics`으로 추가 기입

### 3. `AwsS3Service` 클래스 - 이미지 저장하는 비즈니스 로직 구현
- 확장성을 위해 `StorageService`라는 인터페이스를 만들어 `AwsS3Service` 클래스에서 상속해 주었음
- 참고
   - `upload()` 메서드에 있는 `Tika`
   - 아파치 티카는 csv, pdf 등 다양한 형태의 파일 메타 데이터와 텍스트를 감지하고 추출해주는 라이브러리이다.
   - 해당 라이브러리를 통해 입력받은 파일의 미디어 타입을 추출하여 올바른 파일 형식인지 판단하는 `checkMimeType()`을 호출해주고, 보낼 metadata에 추출한 미디어 타입을 set 한다.
   - metadata에 미디어 타입을 설정하지 않으면, S3 저장소에 파일이 저장될 때 기본 Content-Type인 application/octet-stream으로 저장이 되어 저장 경로를 접근했을 때, 웹에 파일이 출력되는 것이 아닌 파일이 곧바로 다운로드가 돼버린다.

### 업로드가 가능한 서비스와 컨트롤러 만들기
- `ImageTestService` 및 `StorageTestController` 생성(추후 클래스 위치는 다시 고민 해봐야 할듯)

### 업로드 테스트 하기
- Postman으로 Post 요청 보내기
   <img width="731" alt="스크린샷 2024-05-05 오후 10 57 14" src="https://github.com/CHZZK-Study/Grass-Diary-Server/assets/50395809/908efc5a-5874-408c-9830-8735e240543d">
- 이미지 이름 랜덤 생성 후 저장 되는 모습
   ![스크린샷 2024-05-05 오후 10 59 14](https://github.com/CHZZK-Study/Grass-Diary-Server/assets/50395809/69ee7a4e-fe47-4547-86a4-5937d8044853)

---

### 현재 기능에서 더 필요한 부분
- 폴더를 구성하여 이미지 저장 위치 지정하기
- 저장한 이미지 url을 가져와서 DB에 저장하기 → 해당 부분 DB 재설계 필요
- 이미지 삭제하는 로직 필요

---

## 참고 사이트
- [AWS S3 저장소 구축하기](https://willco.tistory.com/11)
- [SpringBoot로 AWS S3에 파일 업로드 하기](https://willco.tistory.com/12)
- [참고한 프로젝트 - Shoe Auction(프로젝트 구조 등)](https://github.com/f-lab-edu/shoe-auction)