### PR TITLE
[feat/hash-tag] 유저가 사용한 해시태그 검색시 usage 함께 반환

### DIFF
--- a/src/main/java/chzzk/grassdiary/domain/diary/controller/DiaryController.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/controller/DiaryController.java
@@ -51,8 +51,8 @@ public class DiaryController {
     }
 
     @GetMapping("/{diaryId}")
-    public DiaryDTO findById(@PathVariable(name = "diaryId") Long diaryId,
-                                     @AuthenticatedMember AuthMemberPayload payload) {
+    public DiaryDetailDTO findById(@PathVariable(name = "diaryId") Long diaryId,
+                                   @AuthenticatedMember AuthMemberPayload payload) {
         return diaryService.findById(diaryId, payload.id());
     }
 
@@ -66,7 +66,7 @@ public class DiaryController {
             description =
                     "최신순 5개씩(`api/diary/main/{memberId}?page=0`), 오래된 순 5개씩(`api/diary/main/1?page=0&sort=createdAt,ASC`) "
                             + "\n페이지를 나타내는 변수가 있는데, 해당 표에는 바로 나타나지 않으니 실행 시켜보시는 것을 추천드립니다.")
-    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = DiaryDTO.class)))
+    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = DiaryDetailDTO.class)))
     public ResponseEntity<?> findAll(
             @PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             @PathVariable Long memberId,

--- a/src/main/java/chzzk/grassdiary/domain/diary/controller/SearchDiaryController.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/controller/SearchDiaryController.java
@@ -2,7 +2,7 @@ package chzzk.grassdiary.domain.diary.controller;
 
 import chzzk.grassdiary.domain.diary.service.DiaryService;
 import chzzk.grassdiary.domain.diary.service.TagService;
-import chzzk.grassdiary.domain.diary.dto.DiaryDTO;
+import chzzk.grassdiary.domain.diary.dto.DiaryDetailDTO;
 import chzzk.grassdiary.domain.diary.dto.TagDTO;
 import chzzk.grassdiary.global.auth.common.AuthenticatedMember;
 import chzzk.grassdiary.global.auth.service.dto.AuthMemberPayload;
@@ -43,7 +43,7 @@ public class SearchDiaryController {
     @Operation(
             summary = "해시태그에 대한 다이어리 검색",
             description = "유저가 해시태그를 선택하면 해당 해시태그를 사용한 다이어리 리스트를 반환")
-    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = DiaryDTO.class)))
+    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = DiaryDetailDTO.class)))
     @Parameters({
             @Parameter(name = "memberId", description = "멤버 아이디"),
             @Parameter(name = "tagId", description = "검색을 원하는 해시태그 아이디")
@@ -64,7 +64,7 @@ public class SearchDiaryController {
             @Parameter(name = "memberId", description = "멤버 아이디"),
             @Parameter(name = "date", description = "검색하는 날짜 String 값(형식: yyyy-MM-dd)")
     })
-    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = DiaryDTO.class)))
+    @ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = DiaryDetailDTO.class)))
     public ResponseEntity<?> searchByDate(
             @PathVariable Long memberId,
             @RequestParam String date,

--- a/src/main/java/chzzk/grassdiary/domain/diary/dto/DiaryDetailDTO.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/dto/DiaryDetailDTO.java
@@ -5,7 +5,7 @@ import chzzk.grassdiary.domain.diary.entity.tag.TagList;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
-public record DiaryDTO(
+public record DiaryDetailDTO(
         Long diaryId,
         String content,
         List<TagList> tags,
@@ -18,8 +18,8 @@ public record DiaryDTO(
         Boolean hasImage,
         String imageURL
 ) {
-    public static DiaryDTO from(Diary diary, List<TagList> tags, boolean isLikedByLogInMember, String imageURL) {
-        return new DiaryDTO(
+    public static DiaryDetailDTO from(Diary diary, List<TagList> tags, boolean isLikedByLogInMember, String imageURL) {
+        return new DiaryDetailDTO(
                 diary.getId(),
                 diary.getContent(),
                 tags,

--- a/src/main/java/chzzk/grassdiary/domain/diary/dto/DiarySaveRequestDTO.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/dto/DiarySaveRequestDTO.java
@@ -17,13 +17,12 @@ public class DiarySaveRequestDTO {
     private Member member;
     private String content;
     private Boolean isPrivate;
-    private Boolean hasImage;
     private Boolean hasTag;
     private ConditionLevel conditionLevel;
     private List<String> hashtags;
 
     // DTO -> Entity
-    public Diary toEntity(Member member) {
+    public Diary toEntity(Member member, Boolean hasImage) {
         return Diary.builder()
                 .member(member)
                 .content(content)

--- a/src/main/java/chzzk/grassdiary/domain/diary/dto/TagDTO.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/dto/TagDTO.java
@@ -1,4 +1,8 @@
 package chzzk.grassdiary.domain.diary.dto;
 
-public record TagDTO(Long tagId, String tag) {
+public record TagDTO(
+        Long tagId,
+        String tag,
+        int usage
+) {
 }

--- a/src/main/java/chzzk/grassdiary/domain/diary/entity/tag/MemberTagsDAO.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/entity/tag/MemberTagsDAO.java
@@ -4,11 +4,12 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface MemberTagsDAO extends JpaRepository<MemberTags, Long> {
-    @Query("SELECT mt.tagList.id FROM MemberTags mt WHERE mt.member.id = :memberId")
-    List<Long> findTagIdsByMemberId(Long memberId);
 
+    // 멤버가 사용한 태그 리스트 반환
+    List<MemberTags> findMemberTagsByMemberId(Long memberId);
+
+    // 멤버가 사용한 태그 반환(태그 유무 조회용)
     Optional<MemberTags> findByMemberIdAndTagList(Long memberId, TagList tagList);
 }

--- a/src/main/java/chzzk/grassdiary/domain/diary/service/DiaryService.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/service/DiaryService.java
@@ -101,16 +101,16 @@ public class DiaryService {
     }
 
     @Transactional(readOnly = true)
-    public DiaryDTO findById(Long diaryId, Long logInMemberId) {
+    public DiaryDetailDTO findById(Long diaryId, Long logInMemberId) {
         Diary diary = getDiaryById(diaryId);
         List<TagList> tags = getTagsByDiary(diaryId);
         boolean isLikedByLoginMember = isDiaryLikedByLoginMember(diaryId, logInMemberId);
 
-        return DiaryDTO.from(diary, tags, isLikedByLoginMember, getImageURL(diary.getHasImage(), diary.getId()));
+        return DiaryDetailDTO.from(diary, tags, isLikedByLoginMember, getImageURL(diary.getHasImage(), diary.getId()));
     }
 
     @Transactional(readOnly = true)
-    public Page<DiaryDTO> findAll(Pageable pageable, Long memberId, Long logInMemberId) {
+    public Page<DiaryDetailDTO> findAll(Pageable pageable, Long memberId, Long logInMemberId) {
         getMemberById(memberId);
 
         return diaryDAO.findDiaryByMemberId(memberId, pageable)
@@ -118,12 +118,12 @@ public class DiaryService {
                     List<TagList> tags = getTagsByDiary(diary.getId());
                     String imageURL = getImageURL(diary.getHasImage(), diary.getId());
                     boolean isLiked = isDiaryLikedByLoginMember(diary.getId(), logInMemberId);
-                    return DiaryDTO.from(diary, tags, isLiked, imageURL);
+                    return DiaryDetailDTO.from(diary, tags, isLiked, imageURL);
                 });
     }
 
     @Transactional(readOnly = true)
-    public DiaryDTO findByDate(Long id, String date, Long logInMemberId) {
+    public DiaryDetailDTO findByDate(Long id, String date, Long logInMemberId) {
         LocalDate localDate = LocalDate.parse(date);
         LocalDateTime startOfDay = localDate.atStartOfDay();
         LocalDateTime endOfDay = localDate.atTime(LocalTime.MAX);
@@ -138,7 +138,7 @@ public class DiaryService {
         List<TagList> tags = getTagsByDiary(diary.getId());
         boolean isLikedByLogInMember = isDiaryLikedByLoginMember(diary.getId(), logInMemberId);
 
-        return DiaryDTO.from(
+        return DiaryDetailDTO.from(
                 diary,
                 tags,
                 isLikedByLogInMember,

--- a/src/main/java/chzzk/grassdiary/domain/diary/service/DiaryService.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/service/DiaryService.java
@@ -53,17 +53,16 @@ public class DiaryService {
     @Transactional
     public DiarySaveResponseDTO save(Long id, DiarySaveRequestDTO requestDto, MultipartFile image) {
         Member member = getMemberById(id);
-        Diary diary = saveDiary(requestDto, member);
+        Diary diary = saveDiary(requestDto, member, image != null);
         saveTags(requestDto.getHashtags(), member, diary);
 
         int rewardPoint = makeRewardPoint();
         saveRewardPointAndHistory(member, rewardPoint);
 
-        if (hasImage(requestDto.getHasImage(), image)) {
-            //TODO: 만약 hasImage가 true인데 image가 비었다면 FE에게 에러 메시지 보낼 것
-            return sendSaveResponseWithImage(diary, image);
+        if (image == null) {
+            return new DiarySaveResponseDTO(diary.getId(), false, "");
         }
-        return new DiarySaveResponseDTO(diary.getId(), false, "");
+        return sendSaveResponseWithImage(diary, image);
     }
 
     private DiarySaveResponseDTO sendSaveResponseWithImage(Diary diary, MultipartFile image) {
@@ -77,7 +76,7 @@ public class DiaryService {
         validateUpdateDate(diary);
         updateTags(diary, requestDto.getHashtags());
 
-        boolean currentHasImage = requestDto.getHasImage();
+        boolean currentHasImage = !(image == null);
         String imagePath = updateDiaryImage(currentHasImage, image, diary);
 
         return updateDiary(requestDto, diary, currentHasImage, imagePath);
@@ -185,8 +184,8 @@ public class DiaryService {
                 .orElseThrow(() -> new SystemException(ClientErrorCode.DIARY_NOT_FOUND_ERR));
     }
 
-    private Diary saveDiary(DiarySaveRequestDTO requestDto, Member member) {
-        return diaryDAO.save(requestDto.toEntity(member));
+    private Diary saveDiary(DiarySaveRequestDTO requestDto, Member member, Boolean hasImage) {
+        return diaryDAO.save(requestDto.toEntity(member, hasImage));
     }
 
     private void saveTags(List<String> hashtags, Member member, Diary diary) {
@@ -224,10 +223,6 @@ public class DiaryService {
         if (rewardHistory.getId() == null) {
             throw new SystemException(ServerErrorCode.REWARD_HISTORY_SAVE_FAILED);
         }
-    }
-
-    private boolean hasImage(Boolean hasImage, MultipartFile file) {
-        return hasImage != null && hasImage && file.getContentType().equals("image/jpeg");
     }
 
     private void validateUpdateDate(Diary diary) {

--- a/src/main/java/chzzk/grassdiary/domain/diary/service/TagService.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/service/TagService.java
@@ -7,7 +7,7 @@ import chzzk.grassdiary.domain.diary.entity.tag.MemberTags;
 import chzzk.grassdiary.domain.diary.entity.tag.MemberTagsDAO;
 import chzzk.grassdiary.domain.diary.entity.tag.TagList;
 import chzzk.grassdiary.domain.diary.entity.tag.TagListDAO;
-import chzzk.grassdiary.domain.diary.dto.DiaryDTO;
+import chzzk.grassdiary.domain.diary.dto.DiaryDetailDTO;
 import chzzk.grassdiary.domain.diary.dto.TagDTO;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -42,7 +42,7 @@ public class TagService {
     /**
      * 유저의 다이어리 태그로 다이어리 검색
      */
-    public List<DiaryDTO> findByHashTagId(Long memberId, Long tagId, Long logInMemberId) {
+    public List<DiaryDetailDTO> findByHashTagId(Long memberId, Long tagId, Long logInMemberId) {
         List<Diary> diaries = diaryTagDAO.findByMemberIdAndTagId(memberId, tagId);
 
         return diaries.stream()
@@ -53,7 +53,7 @@ public class TagService {
                             .toList();
                     boolean isLiked = diaryLikeDAO.findByDiaryIdAndMemberId(diary.getId(), logInMemberId).isPresent();
 
-                    return DiaryDTO.from(diary, tags, isLiked, getImageURL(diary.getHasImage(), diary.getId()));
+                    return DiaryDetailDTO.from(diary, tags, isLiked, getImageURL(diary.getHasImage(), diary.getId()));
                 })
                 .collect(Collectors.toList());
     }

--- a/src/main/java/chzzk/grassdiary/domain/diary/service/TagService.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/service/TagService.java
@@ -32,11 +32,14 @@ public class TagService {
      */
     public List<TagDTO> getMemberTags(Long memberId) {
         // 멤버가 사용한 태그의 tag_id 목록 가져오기
-        List<Long> tagIds = memberTagsDAO.findTagIdsByMemberId(memberId);
+        List<MemberTags> memberTags = memberTagsDAO.findMemberTagsByMemberId(memberId);
 
-        // 태그 DTO 조회
-        return tagListDAO.findTagDTOByIdIn(tagIds).stream()
-                .map(tag -> new TagDTO(tag.getId(), tag.getTag())).toList();
+        return memberTags.stream().map(tag ->
+                new TagDTO(
+                        tag.getId(),
+                        tag.getTagList().getTag(),
+                        tag.getMemberTagUsageCount())
+        ).toList();
     }
 
     /**

--- a/src/main/java/chzzk/grassdiary/domain/diary/service/TagService.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/service/TagService.java
@@ -36,7 +36,7 @@ public class TagService {
 
         return memberTags.stream().map(tag ->
                 new TagDTO(
-                        tag.getId(),
+                        tag.getTagList().getId(),
                         tag.getTagList().getTag(),
                         tag.getMemberTagUsageCount())
         ).toList();
@@ -58,7 +58,7 @@ public class TagService {
 
                     return DiaryDetailDTO.from(diary, tags, isLiked, getImageURL(diary.getHasImage(), diary.getId()));
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private String getImageURL(Boolean hasImage, Long diaryId) {


### PR DESCRIPTION
검색 기능 중 해시태그에 대한 검색이 안 되는 것 같아 수정 중입니다.

- [x] 유저가 사용한 해시태그 검색시 usage 함께 반환
    - `/api/search/hashTag/{memberId}`
- [x] 유저에 해당하는 해시태그 검색시 일기 리스트 반환(기존 코드 확인 필요)
    - `/api/search/tagId/{memberId}?tagId=`