### PR TITLE
fix(DiaryService): 일기 내 이미지 수정시 버그 수정

### DIFF
--- a/src/main/java/chzzk/grassdiary/domain/diary/service/DiaryService.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/service/DiaryService.java
@@ -76,7 +76,7 @@ public class DiaryService {
         validateUpdateDate(diary);
         updateTags(diary, requestDto.getHashtags());
 
-        boolean currentHasImage = !(image == null);
+        boolean currentHasImage = requestDto.getHasImage();
         String imagePath = updateDiaryImage(currentHasImage, image, diary);
 
         return updateDiary(requestDto, diary, currentHasImage, imagePath);
@@ -283,11 +283,11 @@ public class DiaryService {
 
     private String updateDiaryImage(boolean currentHasImage, MultipartFile image, Diary diary) {
         boolean originalHasImage = Boolean.TRUE.equals(diary.getHasImage());
-        if (currentHasImage) {
-            return diaryImageService.updateImage(originalHasImage, image, FileFolder.PERSONAL_DIARY, diary);
-        }
         if (originalHasImage) {
             diaryImageService.deleteImage(diary);
+        }
+        if (currentHasImage) {
+            return diaryImageService.updateImage(originalHasImage, image, FileFolder.PERSONAL_DIARY, diary);
         }
         return "";
     }


### PR DESCRIPTION
- 일기 수정시 hasImage 변수 사용
- 기존 일기에 이미지가 있을 경우 이미지 삭제를 하지 않는 오류 수정(로직 순서 문제 였음)