### PR TITLE
[fix/image-patch] 동일한 이미지를 갖고 있는 일기 PATCH 로직 수정

### DIFF
--- a/src/main/java/chzzk/grassdiary/domain/diary/service/DiaryService.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/service/DiaryService.java
@@ -282,12 +282,22 @@ public class DiaryService {
     }
 
     private DiarySaveResponseDTO updateDiary(DiaryUpdateRequestDTO requestDto, Diary diary) {
-        // 1. 기존에 이미지가 있었다면 이미지와 이미지 매핑 값 삭제
-        diaryImageService.deleteImageAndMapping(diary);
+        // 1. 기존 이미지가 있고, 이미지 id 값이 동일하다면 유지
+        Long newImageId = requestDto.getImageId();
+        Long existImageId = diaryImageService.getImageIdByDiaryId(diary.getId());
 
-        // 2. 이미지 매핑 값 새로 생성
-        if (requestDto.getImageId() != 0) {
-            diaryImageService.mappingImageToDiary(diary, requestDto.getImageId());
+        boolean isSameImage = existImageId.equals(newImageId);
+
+        // 2. 기존 이미지와 다르면
+        if (!isSameImage) {
+            if (existImageId != 0) {
+                // 2-1. 기존에 이미지가 있었다면 이미지와 이미지 매핑 값 삭제
+                diaryImageService.deleteImageAndMapping(diary);
+            }
+            if (newImageId != 0) {
+                // 2-2. 이미지 매핑 값 새로 생성
+                diaryImageService.mappingImageToDiary(diary, newImageId);
+            }
         }
 
         diary.update(requestDto.getContent(), requestDto.getIsPrivate(),

--- a/src/main/java/chzzk/grassdiary/domain/image/dto/ImageDTO.java
+++ b/src/main/java/chzzk/grassdiary/domain/image/dto/ImageDTO.java
@@ -10,6 +10,6 @@ public record ImageDTO (
     private static String baseURL = "https://chzzk-image-server.s3.ap-northeast-2.amazonaws.com/";
 
     public static ImageDTO from(DiaryToImage diaryToImage) {
-        return new ImageDTO(diaryToImage.getId(), baseURL + diaryToImage.getImage().getImagePath());
+        return new ImageDTO(diaryToImage.getImage().getId(), baseURL + diaryToImage.getImage().getImagePath());
     }
 }

--- a/src/main/java/chzzk/grassdiary/domain/image/service/DiaryImageService.java
+++ b/src/main/java/chzzk/grassdiary/domain/image/service/DiaryImageService.java
@@ -19,6 +19,12 @@ public class DiaryImageService {
     private final ImageService imageService;
     private final DiaryToImageDAO diaryToImageDAO;
 
+    public Long getImageIdByDiaryId(Long diaryId) {
+        return diaryToImageDAO.findByDiaryId(diaryId)
+                .map(diaryToImage -> diaryToImage.getImage().getId())
+                .orElse(0L);
+    }
+
     /**
      * FRONT: 이미지 id와 Diary 값을 주면 검색해서 둘을 잇는 값을 추가
      */


### PR DESCRIPTION
## 주요 수정 내역

- 동일한 이미지를 갖고 있는 일기의 경우 새로운 이미지를 요청하지 않음


## 그 외 버그 수정
ImageDTO
- image id를 전송해야 하는데, 이미지 매핑 값을 전송 하던 것을 수정