### PR TITLE
fix(diary) : 일기 코드 수정

### DIFF
--- a/src/main/java/chzzk/grassdiary/domain/comment/entity/CommentDAO.java
+++ b/src/main/java/chzzk/grassdiary/domain/comment/entity/CommentDAO.java
@@ -2,7 +2,6 @@ package chzzk.grassdiary.domain.comment.entity;
 
 import java.util.List;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 

--- a/src/main/java/chzzk/grassdiary/domain/diary/controller/DiaryController.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/controller/DiaryController.java
@@ -42,8 +42,9 @@ public class DiaryController {
     }
 
     @DeleteMapping("/{diaryId}")
-    public Long delete(@PathVariable(name = "diaryId") Long diaryId) {
-        diaryService.delete(diaryId);
+    public Long delete(@PathVariable(name = "diaryId") Long diaryId,
+                       @AuthenticatedMember AuthMemberPayload payload) {
+        diaryService.delete(diaryId, payload.id());
         return diaryId;
     }
 

--- a/src/main/java/chzzk/grassdiary/domain/diary/service/DiaryService.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/service/DiaryService.java
@@ -83,8 +83,11 @@ public class DiaryService {
      * 이미지 삭제
      */
     @Transactional
-    public void delete(Long diaryId) {
+    public void delete(Long diaryId, Long logInMemberId) {
         Diary diary = getDiaryById(diaryId);
+
+        validateDiaryOwner(diary, logInMemberId);
+
         removeDiaryComments(diary);
         removeExistingTags(diary);
         removeDiaryLikes(diaryId);
@@ -244,6 +247,12 @@ public class DiaryService {
                 .ifPresent(diaryLike -> {
                     throw new SystemException(ClientErrorCode.DIARY_LIKE_ALREADY_EXISTS);
                 });
+    }
+
+    private void validateDiaryOwner(Diary diary, Long logInMemberId) {
+        if (!diary.getMember().getId().equals(logInMemberId)) {
+            throw new SystemException(ClientErrorCode.AUTHOR_MISMATCH_ERR);
+        }
     }
 
     private void removeDiaryComments(Diary diary) {

--- a/src/main/java/chzzk/grassdiary/domain/diary/service/DiaryService.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/service/DiaryService.java
@@ -1,5 +1,7 @@
 package chzzk.grassdiary.domain.diary.service;
 
+import chzzk.grassdiary.domain.comment.entity.Comment;
+import chzzk.grassdiary.domain.comment.entity.CommentDAO;
 import chzzk.grassdiary.domain.image.dto.ImageDTO;
 import chzzk.grassdiary.domain.image.entity.DiaryToImageDAO;
 import chzzk.grassdiary.domain.image.service.DiaryImageService;
@@ -49,6 +51,7 @@ public class DiaryService {
     private final MemberDAO memberDAO;
     private final DiaryTagDAO diaryTagDAO;
     private final RewardHistoryDAO rewardHistoryDAO;
+    private final CommentDAO commentDAO;
 
     private final DiaryImageService diaryImageService;
     private final DiaryToImageDAO diaryToImageDAO;
@@ -82,6 +85,7 @@ public class DiaryService {
     @Transactional
     public void delete(Long diaryId) {
         Diary diary = getDiaryById(diaryId);
+        removeDiaryComments(diary);
         removeExistingTags(diary);
         removeDiaryLikes(diaryId);
         diaryImageService.deleteImageAndMapping(diary);
@@ -240,6 +244,21 @@ public class DiaryService {
                 .ifPresent(diaryLike -> {
                     throw new SystemException(ClientErrorCode.DIARY_LIKE_ALREADY_EXISTS);
                 });
+    }
+
+    private void removeDiaryComments(Diary diary) {
+        List<Comment> comments = diary.getComments();
+        for (Comment comment : comments) {
+            removeChildComments(comment);
+        }
+    }
+
+    private void removeChildComments(Comment parentComment) {
+        List<Comment> childComments = parentComment.getChildComments();
+        for (Comment childComment : childComments) {
+            removeChildComments(childComment);  // 재귀적으로 자식 댓글 삭제
+        }
+        commentDAO.delete(parentComment);
     }
 
     private void removeExistingTags(Diary diary) {


### PR DESCRIPTION
1. 댓글 entity는 일기 entity의 자식 entity로, 해당 일기 데이터와 연관된 댓글 데이터의 삭제가 선행되어야 일기 데이터가 삭제될 수 있습니다. 
일기를 삭제하고자 할 때 댓글 데이터를 삭제하도록 수정했습니다.

2. 일기 작성자만 일기를 삭제할 수 있어야하는데, 이러한 검증이 서버에서는 이루어지고 있지 않았습니다. -> 일기 작성자만 일기를 삭제할 수 있도록 검증하는 코드 추가