### PR TITLE
[feat/public-url] 랭킹 및 최신 일기 나열 페이지 기능 요구 사항 변경 

### DIFF
--- a/src/main/java/chzzk/grassdiary/domain/diary/dto/browse/AllLatestDiariesDto.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/dto/browse/AllLatestDiariesDto.java
@@ -1,16 +1,15 @@
 package chzzk.grassdiary.domain.diary.dto.browse;
 
-import chzzk.grassdiary.domain.diary.entity.Diary;
 import java.util.List;
 
 public record AllLatestDiariesDto(
         LatestMetaDto meta,
         List<DiaryPreviewDTO> diaries
 ) {
-    public static AllLatestDiariesDto of(List<Diary> diaries, boolean hasMore) {
+    public static AllLatestDiariesDto of(List<DiaryPreviewDTO> diaries, boolean hasMore) {
         return new AllLatestDiariesDto(
-                LatestMetaDto.of(diaries.size(), hasMore),
-                DiaryPreviewDTO.toLatestDiariesDto(diaries)
+                new LatestMetaDto(diaries.size(), hasMore),
+                diaries
         );
     }
 }

--- a/src/main/java/chzzk/grassdiary/domain/diary/dto/browse/DiaryPreviewDTO.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/dto/browse/DiaryPreviewDTO.java
@@ -1,9 +1,13 @@
 package chzzk.grassdiary.domain.diary.dto.browse;
 
 import chzzk.grassdiary.domain.diary.entity.Diary;
+import chzzk.grassdiary.domain.diary.service.DiaryService;
+import chzzk.grassdiary.domain.image.dto.ImageDTO;
+
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 import org.springframework.data.domain.Page;
 
@@ -15,24 +19,17 @@ public record DiaryPreviewDTO(
         float transparency,
         Long memberId,
         String nickname,
-        String createdAt) {
+        String createdAt,
+        List<ImageDTO> image
+    ) {
 
-    public static List<DiaryPreviewDTO> of(Page<Diary> diaries) {
+    public static List<DiaryPreviewDTO> of(Page<Diary> diaries, Function<Long, List<ImageDTO>> imageLoader) {
         return diaries.stream()
-                .map(d -> new DiaryPreviewDTO(
-                        d.getId(),
-                        trimContent(d.getContent()),
-                        d.getDiaryLikes().size(),
-                        d.getComments().size(),
-                        d.getConditionLevel().getTransparency(),
-                        d.getMember().getId(),
-                        d.getMember().getNickname(),
-                        d.getCreatedAt()
-                                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
-                )).toList();
+                .map(d -> toPreviewDiary(d, imageLoader.apply(d.getId())))
+                .toList();
     }
 
-    private static DiaryPreviewDTO toPreviewDiary(Diary diary) {
+    public static DiaryPreviewDTO toPreviewDiary(Diary diary, List<ImageDTO> images) {
         return new DiaryPreviewDTO(
                 diary.getId(),
                 trimContent(diary.getContent()),
@@ -42,14 +39,9 @@ public record DiaryPreviewDTO(
                 diary.getMember().getId(),
                 diary.getMember().getNickname(),
                 diary.getCreatedAt()
-                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
+                images
         );
-    }
-
-    public static List<DiaryPreviewDTO> toLatestDiariesDto(List<Diary> diaries) {
-        return diaries.stream()
-                .map(DiaryPreviewDTO::toPreviewDiary)
-                .toList();
     }
 
     private static String trimContent(String content) {

--- a/src/main/java/chzzk/grassdiary/domain/diary/dto/browse/LatestMetaDto.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/dto/browse/LatestMetaDto.java
@@ -3,11 +3,4 @@ package chzzk.grassdiary.domain.diary.dto.browse;
 public record LatestMetaDto(
         int count,
         boolean hasMore
-) {
-    public static LatestMetaDto of(int count, boolean hasMore) {
-        return new LatestMetaDto(
-                count,
-                hasMore
-        );
-    }
-}
+) {}

--- a/src/main/java/chzzk/grassdiary/domain/diary/service/DiaryService.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/service/DiaryService.java
@@ -30,7 +30,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +41,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class DiaryService {
     private final DiaryDAO diaryDAO;
@@ -56,7 +56,6 @@ public class DiaryService {
     private final DiaryImageService diaryImageService;
     private final DiaryToImageDAO diaryToImageDAO;
 
-    @Transactional
     public DiarySaveResponseDTO save(Long id, DiarySaveRequestDTO requestDto) {
         Member member = getMemberById(id);
         // 게시글 저장, 이미지가 있다면 매핑값 저장
@@ -69,7 +68,6 @@ public class DiaryService {
         return new DiarySaveResponseDTO(diary.getId());
     }
 
-    @Transactional
     public DiarySaveResponseDTO update(Long id, DiaryUpdateRequestDTO requestDto) {
         Diary originalDiary = getDiaryById(id);
         validateUpdateDate(originalDiary);
@@ -82,7 +80,6 @@ public class DiaryService {
      * diaryId를 이용해서 diaryTag, MemberTag 를 찾아내기 diaryTag 삭제 -> deleteAllInBatch 고려해보기 MemberTag 삭제 해당 일기의 좋아요 찾기 및 삭제
      * 이미지 삭제
      */
-    @Transactional
     public void delete(Long diaryId, Long logInMemberId) {
         Diary diary = getDiaryById(diaryId);
 
@@ -105,7 +102,7 @@ public class DiaryService {
         return DiaryDetailDTO.from(diary, tags, isLikedByLoginMember, getImagesByDiary(diaryId));
     }
 
-    private List<ImageDTO> getImagesByDiary(Long diaryId) {
+    public List<ImageDTO> getImagesByDiary(Long diaryId) {
         return diaryToImageDAO.findByDiaryId(diaryId)
                 .stream()
                 .map(ImageDTO::from)
@@ -148,7 +145,6 @@ public class DiaryService {
         );
     }
 
-    @Transactional
     public Long addLike(Long diaryId, Long memberId) {
         Diary diary = getDiaryById(diaryId);
         Member member = getMemberById(memberId);
@@ -165,7 +161,6 @@ public class DiaryService {
         return diaryId;
     }
 
-    @Transactional
     public Long deleteLike(Long diaryId, Long memberId) {
         getDiaryById(diaryId);
 

--- a/src/main/java/chzzk/grassdiary/global/auth/filter/JwtAuthFilter.java
+++ b/src/main/java/chzzk/grassdiary/global/auth/filter/JwtAuthFilter.java
@@ -33,7 +33,8 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     );
 
     private final List<String> publicPaths = List.of(
-            "/api/shared/diaries"
+            "/api/shared/diaries",
+            "/api/member/profile"
     );
 
     private void setCorsHeaders(HttpServletRequest request, HttpServletResponse response) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #150 #158 

## 📝작업 내용

- 로그인 하지 않아도 읽기 가능한 페이지 추가(프로필 사진)
- 랭킹 및 최신 일기 나열 페이지 이미지 추가
  - DiaryService 클래스 내 getImagesByDiary() 메서드 재사용
  - DTO에 DiaryService를 주입시켜 활용하는 것이 아닌 추상화된 함수를 주입 받음으로써 DiaryPreviewDTO가 특정 서비스 클래스에 직접적으로 의존하지 않도록 구현
  - 그 외 필요 없는 메서드 삭제와 함께 `@transactional` 메서드 사용을 확실히 하기 위해 위치 및 범위가 조금씩 변경 되었습니다.