### PR TITLE
[test] 테스트를 위한 패키지 추가 및 일기 랭킹 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'java-test-fixtures'
     id 'org.springframework.boot' version '3.2.2'
     id 'io.spring.dependency-management' version '1.1.4'
 }
@@ -33,8 +34,6 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
@@ -48,6 +47,17 @@ dependencies {
     // aws s3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     implementation group: 'org.apache.tika', name: 'tika-parsers', version: '1.25'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testFixturesImplementation 'jakarta.persistence:jakarta.persistence-api:3.0.0'
+
+    // FixtureMonkey
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.9.0")
+    testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:1.0.23")
+
+    // Lombok for test
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 compileJava {

--- a/src/main/java/chzzk/grassdiary/domain/diary/dto/browse/DiaryPreviewDTO.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/dto/browse/DiaryPreviewDTO.java
@@ -1,7 +1,6 @@
 package chzzk.grassdiary.domain.diary.dto.browse;
 
 import chzzk.grassdiary.domain.diary.entity.Diary;
-import chzzk.grassdiary.domain.diary.service.DiaryService;
 import chzzk.grassdiary.domain.image.dto.ImageDTO;
 
 import java.time.format.DateTimeFormatter;

--- a/src/main/java/chzzk/grassdiary/domain/member/entity/Member.java
+++ b/src/main/java/chzzk/grassdiary/domain/member/entity/Member.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.Size;
+
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -55,8 +56,8 @@ public class Member extends BaseTimeEntity {
 
     private String profileIntro;
 
-    @OneToMany
-    private List<Diary> diaries = new ArrayList<>();
+    @OneToMany(fetch = FetchType.LAZY)
+    private final List<Diary> diaries = new ArrayList<>();
 
     public Member(String nickname, String email, ColorCode currentColorCode) {
         this.nickname = nickname;

--- a/src/test/java/chzzk/grassdiary/domain/diary/service/BrowseDiaryServiceTest.java
+++ b/src/test/java/chzzk/grassdiary/domain/diary/service/BrowseDiaryServiceTest.java
@@ -1,0 +1,129 @@
+package chzzk.grassdiary.domain.diary.service;
+
+import chzzk.grassdiary.domain.color.ColorCode;
+import chzzk.grassdiary.domain.color.ColorCodeDAO;
+import chzzk.grassdiary.domain.color.ConditionLevel;
+import chzzk.grassdiary.domain.diary.dto.browse.DiaryPreviewDTO;
+import chzzk.grassdiary.domain.diary.entity.Diary;
+import chzzk.grassdiary.domain.diary.entity.DiaryDAO;
+import chzzk.grassdiary.domain.diary.entity.DiaryLike;
+import chzzk.grassdiary.domain.diary.entity.DiaryLikeDAO;
+import chzzk.grassdiary.domain.member.entity.Member;
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.BuilderArbitraryIntrospector;
+import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
+import net.jqwik.api.Arbitraries;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+@Transactional
+class BrowseDiaryServiceTest {
+
+    @InjectMocks
+    private BrowseDiaryService browseDiaryService;
+
+    @Mock
+    private DiaryDAO diaryDAO;
+
+    @Mock
+    private DiaryLikeDAO diaryLikeDAO;
+
+    @Mock
+    private DiaryService diaryService;
+
+    @Mock
+    private ColorCodeDAO colorCodeDAO;
+
+    private FixtureMonkey fixtureMonkey;
+
+    List<Diary> diaries;
+    Member member;
+
+    @BeforeEach
+    void setUp() {
+        fixtureMonkey = FixtureMonkey.builder()
+                .objectIntrospector(BuilderArbitraryIntrospector.INSTANCE)
+                .build();
+
+        member = fixtureMonkey.giveMeBuilder(Member.class)
+                .set("currentColorCode", new ColorCode())
+                .sample();
+
+        // 다이어리 여러 개 생성(좋아요가 여러 개 달린)
+        diaries = fixtureMonkey.giveMeBuilder(Diary.class)
+                .set("member", member)
+                .set("conditionLevel", fixtureMonkey.giveMeOne(ConditionLevel.class))
+                .sampleList(20);
+
+        // 각 Diary 객체에 대해 랜덤한 DiaryLike 리스트를 설정
+        diaries.forEach(diary -> {
+            diary.setDiaryLikes(
+                    fixtureMonkey.giveMeBuilder(DiaryLike.class)
+                            .set("member", member)
+                            .sampleList(Arbitraries.integers().between(1, 20).sample())
+            );
+            log.info(diary.getContent());
+        });
+    }
+
+    @Test
+    @DisplayName("이번주 Top10 일기들을 볼 수 있다. (좋아요, 최신 순 정렬)")
+    void findTop10DiariesThisWeek() {
+        int expectedSize = 10;
+        // given
+        // 좋아요 수와 생성 날짜로 정렬
+        List<Diary> sortedDiaries = diaries.stream()
+                .sorted(Comparator.comparing((Diary d) -> d.getDiaryLikes().size()).reversed()
+                        .thenComparing(Diary::getCreatedAt))
+                .limit(10)
+                .collect(Collectors.toList());
+
+        // Mock 설정
+        when(diaryDAO.findTop10DiariesThisWeek(any(), any(), any()))
+                .thenReturn(new PageImpl<>(sortedDiaries, PageRequest.of(0, 10), sortedDiaries.size()));
+
+        when(diaryService.getImagesByDiary(any())).thenReturn(Collections.emptyList());
+
+        // when
+        List<DiaryPreviewDTO> result = browseDiaryService.findTop10DiariesThisWeek();
+
+        // then
+        assertNotNull(result);
+        assertEquals(expectedSize, result.size());
+
+        // 좋아요 개수 순서 확인
+        for (int i = 0; i < expectedSize - 1; i++) {
+            DiaryPreviewDTO current = result.get(i);
+            DiaryPreviewDTO next = result.get(i + 1);
+            assertTrue(current.diaryLikeCount() >= next.diaryLikeCount());
+        }
+
+        verify(diaryDAO).findTop10DiariesThisWeek(any(LocalDateTime.class), any(LocalDateTime.class), any(PageRequest.class));
+        verify(diaryService, times(expectedSize)).getImagesByDiary(any());
+    }
+
+}

--- a/src/test/java/chzzk/grassdiary/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/chzzk/grassdiary/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,82 @@
+package chzzk.grassdiary.domain.member.service;
+
+import chzzk.grassdiary.domain.color.ColorCodeDAO;
+import chzzk.grassdiary.domain.member.entity.Member;
+import chzzk.grassdiary.domain.member.entity.MemberDAO;
+import chzzk.grassdiary.global.auth.service.dto.GoogleUserInfo;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Mock
+    private MemberDAO memberDAO;
+
+    @Mock
+    private ColorCodeDAO colorCodeDAO;
+
+    FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+            .objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+            .build();
+
+    @Test
+    @DisplayName("회원가입 되어 있지 않은 경우 신규 멤버로 데이터가 추가 되어야 한다.")
+    void createMemberIfNotExist_whenMemberDoesNotExist() {
+        // given
+        GoogleUserInfo googleUserInfo = fixtureMonkey.giveMeOne(GoogleUserInfo.class);
+
+        when(memberDAO.findByEmail(googleUserInfo.email())).thenReturn(Optional.empty());
+        when(memberDAO.save(any(Member.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        Member createdMember = memberService.createMemberIfNotExist(googleUserInfo);
+
+        // then
+        then(createdMember).isNotNull();
+        then(createdMember.getNickname()).isEqualTo(googleUserInfo.nickname());
+        then(createdMember.getEmail()).isEqualTo(googleUserInfo.email());
+        then(createdMember.getPicture()).isEqualTo(googleUserInfo.picture());
+        
+        verify(memberDAO).findByEmail(googleUserInfo.email());
+        verify(memberDAO).save(any(Member.class));
+    }
+
+    @Test
+    @DisplayName("회원가입이 이미 되어있는 경우 멤버 데이터를 추가하지 않는다.")
+    void createMemberIfNotExist_whenMemberAlreadyExists() {
+        // given
+        GoogleUserInfo googleUserInfo = fixtureMonkey.giveMeOne(GoogleUserInfo.class);
+        Member existingMember = fixtureMonkey.giveMeOne(Member.class);
+
+        when(memberDAO.findByEmail(googleUserInfo.email())).thenReturn(Optional.of(existingMember));
+
+        // when
+        Member result = memberService.createMemberIfNotExist(googleUserInfo);
+
+        // then
+        then(result).isEqualTo(existingMember);
+        verify(memberDAO).findByEmail(googleUserInfo.email());
+        verify(memberDAO, never()).save(any(Member.class));
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #39

## 📝작업 내용

1. 테스트를 위한 패키지들이 추가 되었습니다.
2. MemberService를 위한 테스트가 추가 되었습니다.
    - 멤버가 이미 존재할 때/존재하지 않을 때 멤버 데이터 추가 유무에 대한 테스트
4. BrowseDiaryService를 위한 테스트가 추가 되었습니다.
    - 이번주 일기 랭킹 Top10에 대한 테스트