### PR TITLE
[fix/cors] CORS URL 추가 및 클래스의 관심사 분리

### DIFF
--- a/src/main/java/chzzk/grassdiary/global/auth/filter/JwtAuthFilter.java
+++ b/src/main/java/chzzk/grassdiary/global/auth/filter/JwtAuthFilter.java
@@ -13,8 +13,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -27,36 +27,19 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     private final JwtTokenExtractor jwtTokenExtractor;
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberDAO memberDAO;
-    private final List<String> allowedOrigins = Arrays.asList(
-        "https://grassdiary.site",
-        "http://localhost:3000"
-    );
 
-    private final List<String> publicPaths = List.of(
-            "/api/shared/diaries",
-            "/api/member/profile"
+    private final List<String> publicPaths = Arrays.asList(
+        "/api/auth",
+        "/api/shared/diaries",
+        "/api/member/profile"
     );
-
-    private void setCorsHeaders(HttpServletRequest request, HttpServletResponse response) {
-        String origin = request.getHeader("Origin");
-        if (allowedOrigins.contains(origin)) {
-            response.setHeader("Access-Control-Allow-Origin", origin);
-        }
-        response.setHeader("Access-Control-Allow-Methods", "*");
-        response.setHeader("Access-Control-Allow-Headers",
-                "authorization, content-type, accept, origin, x-requested-with");
-        response.setHeader("Access-Control-Allow-Credentials", "true");
-        response.setHeader("Access-Control-Max-Age", "3600");
-    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-
-        setCorsHeaders(request, response);
-
         String path = request.getRequestURI();
-        if (isPublicPath(path) || request.getMethod().equals("OPTIONS")) {
+        
+        if (isPublicPath(path)) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/java/chzzk/grassdiary/global/config/WebMvcConfig.java
+++ b/src/main/java/chzzk/grassdiary/global/config/WebMvcConfig.java
@@ -3,15 +3,21 @@ package chzzk.grassdiary.global.config;
 import chzzk.grassdiary.global.auth.common.AuthMemberResolver;
 import chzzk.grassdiary.global.auth.filter.JwtAuthFilter;
 import jakarta.servlet.Filter;
+
+import java.util.Arrays;
 import java.util.List;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.filter.CorsFilter;
 
 @Configuration
 @EnableWebMvc
@@ -25,23 +31,36 @@ public class WebMvcConfig implements WebMvcConfigurer {
         resolvers.add(authMemberResolver);
     }
 
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+            .allowedOrigins("http://localhost:3000", "https://grassdiary.site")
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+            .allowedHeaders("*")
+            .allowCredentials(true);
+    }
+
     @Bean
     public FilterRegistrationBean<Filter> authFilter() {
         FilterRegistrationBean<Filter> registration = new FilterRegistrationBean<>();
         registration.setFilter(jwtAuthFilter);
         registration.setOrder(1);
-        registration.addUrlPatterns(
-                "/api/example",
-                "/api/test",
-                "/api/diary/*",
-                "/api/grass/*",
-                "/api/main/*",
-                "/api/member/*",
-                "/api/search/*",
-                "/api/shared/diaries/*",
-                "/api/members/me",
-                "/api/me"
-        );
+        registration.addUrlPatterns("/*"); // 모든 경로에 대해 필터 적용
         return registration;
+    }
+
+    @Bean
+    public FilterRegistrationBean<CorsFilter> corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.setAllowedOrigins(Arrays.asList("http://localhost:3000", "https://grassdiary.site"));
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+        source.registerCorsConfiguration("/**", config);
+        CorsFilter corsFilter = new CorsFilter(source);
+        FilterRegistrationBean<CorsFilter> bean = new FilterRegistrationBean<>(corsFilter);
+        bean.setOrder(0);
+        return bean;
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #46 

## 📝작업 내용

`JwtAuthFilter` 클래스와 `WebMvcConfig` 클래스의 관심사가 분리되었습니다.

- `JwtAuthFilter` 클래스에서 CORS를 담당하던 것을 `WebMvcConfig` 클래스에서 CORS를 담당하도록 수정하였습니다.
- `JwtAuthFilter` 클래스에서는 `인증`만 담당하도록 하였습니다.
    - 기존에 모든 요청이 블랙 리스트 기반으로 모두 허용 됐었으나, 모든 요청을 화이트 리스트 기반으로 변경하여 `public`이어야 하는 URL만 관리할 수 있도록 변경하였습니다.
