### PR TITLE
[feat/monitoring] Actuator 패키지 및 jpa.open-in-view=false 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
     // Lombok for test
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
+
+    // 모니터링을 위한 패키지
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 compileJava {

--- a/src/main/java/chzzk/grassdiary/global/auth/filter/JwtAuthFilter.java
+++ b/src/main/java/chzzk/grassdiary/global/auth/filter/JwtAuthFilter.java
@@ -29,9 +29,15 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     private final MemberDAO memberDAO;
 
     private final List<String> publicPaths = Arrays.asList(
+        "/swagger-ui",
+        "/v3/api-docs",
+        "/api/diary/today-question",
+        "/api/main/today-date",
         "/api/auth",
         "/api/shared/diaries",
-        "/api/member/profile"
+        "/api/member/profile",
+        "/api/image",
+        "/actuator"
     );
 
     @Override

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,9 +31,11 @@ cloud.aws.region.static=ap-northeast-2
 cloud.aws.region.statics=ap-northeast-2
 cloud.aws.stack.auto=false
 
-# ????? ?? ??
+# actuator-monitoring-config
 #management.endpoints.web.exposure.include=*
 #management.endpoint.health.show-details: always
-# JPA/Hibernate? ?? ?? ? ?? ?? ?? ??? ??
+# JPA/Hibernate-statistics
 #spring.jpa.properties.hibernate.generate_statistics=true
 
+# persistence context of JPA remains open until the HTTP request is completed
+spring.jpa.open-in-view=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,7 +21,7 @@ oauth2.client.provider.google.token-uri=https://oauth2.googleapis.com/token
 oauth2.client.provider.google.user-info-uri=https://www.googleapis.com/oauth2/v1/userinfo
 jwt.access.secret-key=${JWT_ACCESS_SECRET_KEY}
 jwt.access.expiration=1800000
-client.login-success-redirect-uri=https://grassdiary.site/main
+client.login-success-redirect-uri=http://localhost:3000/main
 
 # aws-s3-config
 cloud.aws.credentials.accessKey=${S3_ACCESS_PUBLIC_KEY}
@@ -30,3 +30,10 @@ cloud.aws.s3.bucket=${S3_BUCKET_NAME}
 cloud.aws.region.static=ap-northeast-2
 cloud.aws.region.statics=ap-northeast-2
 cloud.aws.stack.auto=false
+
+# ????? ?? ??
+#management.endpoints.web.exposure.include=*
+#management.endpoint.health.show-details: always
+# JPA/Hibernate? ?? ?? ? ?? ?? ?? ??? ??
+#spring.jpa.properties.hibernate.generate_statistics=true
+


### PR DESCRIPTION
## #️⃣연관된 이슈

> X

## 📝작업 내용

- 모니터링용 빌드 패키지(actuator)를 추가 했습니다.
- `spring.jpa.open-in-view=false` 설정을 했습니다.
    - 기본이 `true` 값으로 설정 되어있으며, `false`를 해주면 영속성 컨텍스트가 트랜잭션이 끝날 때(즉, 보통 컨트롤러에서 데이터 처리가 끝나는 시점) 닫히게 됩니다. DB 쿼리 최적화를 위해 추가해주었습니다.