### PR TITLE
Feat/comment pagination

### DIFF
--- a/src/main/java/chzzk/grassdiary/domain/comment/dto/CommentResponseDTO.java
+++ b/src/main/java/chzzk/grassdiary/domain/comment/dto/CommentResponseDTO.java
@@ -15,6 +15,7 @@ public record CommentResponseDTO(
         String createdDate,
         String createdAt,
         int depth,
+        Long group,
         List<CommentResponseDTO> childComments
 ) {
     public static CommentResponseDTO from(Comment comment) {
@@ -26,6 +27,7 @@ public record CommentResponseDTO(
                 comment.getCreatedAt().format(DateTimeFormatter.ofPattern("yy년 MM월 dd일")),
                 comment.getCreatedAt().format(DateTimeFormatter.ofPattern("HH:mm")),
                 comment.getDepth(),
+                comment.getGroup(),
                 comment.getChildComments().stream().map(CommentResponseDTO::fromComment).collect(Collectors.toList())
         );
     }
@@ -36,9 +38,10 @@ public record CommentResponseDTO(
                 null,
                 null,
                 true,
-                null,
-                null,
+                comment.getCreatedAt().format(DateTimeFormatter.ofPattern("yy년 MM월 dd일")),
+                comment.getCreatedAt().format(DateTimeFormatter.ofPattern("HH:mm")),
                 comment.getDepth(),
+                comment.getGroup(),
                 comment.getChildComments().stream().map(CommentResponseDTO::fromComment).collect(Collectors.toList())
         );
     }

--- a/src/main/java/chzzk/grassdiary/domain/comment/entity/Comment.java
+++ b/src/main/java/chzzk/grassdiary/domain/comment/entity/Comment.java
@@ -49,13 +49,13 @@ public class Comment extends BaseTimeEntity {
     @OneToMany(mappedBy = "parentComment", cascade = CascadeType.ALL)
     private List<Comment> childComments = new ArrayList<>();
 
-//    @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL)
-//    private List<CommentLike> commentLikes = new ArrayList<>();
-
     private boolean deleted;
 
     @Column(nullable = false)
     private int depth;
+
+    @Column(name = "comment_group")
+    private Long group;
 
     @Builder
     protected Comment(Member member, Diary diary, String content, Comment parentComment, int depth) {
@@ -73,5 +73,9 @@ public class Comment extends BaseTimeEntity {
 
     public void delete() {
         this.deleted = true;
+    }
+
+    public void assignGroup(Long groupValue) {
+        this.group = groupValue;
     }
 }

--- a/src/main/java/chzzk/grassdiary/domain/comment/entity/CommentDAO.java
+++ b/src/main/java/chzzk/grassdiary/domain/comment/entity/CommentDAO.java
@@ -6,6 +6,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface CommentDAO extends JpaRepository<Comment, Long> {
-    @Query("select c from Comment c join fetch c.member left join fetch c.parentComment where c.diary.id = :diaryId order by c.parentComment.id asc nulls first, c.id asc")
+    @Query("""
+    select c 
+    from Comment c 
+    join fetch c.member 
+    left join fetch c.parentComment 
+    where c.diary.id = :diaryId 
+    order by c.parentComment.id asc nulls first, c.id asc
+    """)
     List<Comment> findAllByDiaryId(Long diaryId, Pageable pageable);
 }

--- a/src/main/java/chzzk/grassdiary/domain/comment/service/CommentService.java
+++ b/src/main/java/chzzk/grassdiary/domain/comment/service/CommentService.java
@@ -38,10 +38,23 @@ public class CommentService {
 
         int commentDepth = calculateCommentDepth(parentComment);
         validateCommentDepth(commentDepth);
+
         Comment comment = requestDTO.toEntity(member, diary, parentComment, commentDepth);
-        commentDAO.save(comment);
+        commentDAO.saveAndFlush(comment);
+
+        assignGroupToComment(comment, parentComment);
 
         return CommentResponseDTO.from(comment);
+    }
+
+    private void assignGroupToComment(Comment comment, Comment parentComment) {
+        if (parentComment == null) {
+            // For parent comments, group is its own ID
+            comment.assignGroup(comment.getId());
+        } else {
+            // For child comments, group is the parent's group
+            comment.assignGroup(parentComment.getGroup());
+        }
     }
 
     @Transactional

--- a/src/main/java/chzzk/grassdiary/domain/image/dto/ImageDTO.java
+++ b/src/main/java/chzzk/grassdiary/domain/image/dto/ImageDTO.java
@@ -7,7 +7,7 @@ public record ImageDTO (
         Long imageId,
         String imageURL
 ) {
-    private static String baseURL = "https://chzzk-image-server.s3.ap-northeast-2.amazonaws.com/";
+    private static String baseURL = "https://chzzk-image-server-dev.s3.ap-northeast-2.amazonaws.com/";
 
     public static ImageDTO from(DiaryToImage diaryToImage) {
         return new ImageDTO(diaryToImage.getImage().getId(), baseURL + diaryToImage.getImage().getImagePath());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,7 +21,7 @@ oauth2.client.provider.google.token-uri=https://oauth2.googleapis.com/token
 oauth2.client.provider.google.user-info-uri=https://www.googleapis.com/oauth2/v1/userinfo
 jwt.access.secret-key=${JWT_ACCESS_SECRET_KEY}
 jwt.access.expiration=1800000
-client.login-success-redirect-uri=https://grassdiary.site/main
+client.login-success-redirect-uri=http://localhost:3000/main
 
 # aws-s3-config
 cloud.aws.credentials.accessKey=${S3_ACCESS_PUBLIC_KEY}


### PR DESCRIPTION
## #️⃣연관된 이슈

아직 작업중입니다!

## 📝작업 내용
## 1. Comment entity 변경 사항

- group entity 추가
- assignGroup추가

## 2. Comment Service 변경 사항

부모 댓글인 경우 자신의 id값을 가져야 하므로 saveAndFlush 후 id값을 가진 후에 group의 값을 변경하도록 합니다.

save()메서드의 경우 @transactional로 관리되고 있습니다. Hibernate의 경우, SQL연산을 즉시 수행하지 않고, 트랜잭션 커밋 시점이나 플러시가 발생할 때까지 연기합니다.(Hibernate의 쓰기 지연 전략).  따라서 그냥 commentDAO.save(comment)를 하게 되면  group에는 null값이 담기게 됩니다. 따라서 flush()를 사용하여 즉시 INSERT 하여 지금까지의 변경 사항을 데이터베이스에 즉시 반영하도록 한 후에 group에 id값을 넣어주도록 했습니다.

## 3. CommentResponseDTO 변경 사항

1. group 값을 반환하도록 추가
2. 삭제된 댓글이 comment_id, group, created_at값은 null이 아닌 값으로 response해주도록 변경

