### PR TITLE
[feat/profile] 사용자 기본 정보 확인시 이메일 추가 

### DIFF
--- a/src/main/java/chzzk/grassdiary/domain/member/dto/MemberInfoDTO.java
+++ b/src/main/java/chzzk/grassdiary/domain/member/dto/MemberInfoDTO.java
@@ -3,6 +3,7 @@ package chzzk.grassdiary.domain.member.dto;
 public record MemberInfoDTO(
         String profileImageURL,
         String nickname,
-        String profileIntro
+        String profileIntro,
+        String email
 ) {
 }

--- a/src/main/java/chzzk/grassdiary/domain/member/service/MyPageService.java
+++ b/src/main/java/chzzk/grassdiary/domain/member/service/MyPageService.java
@@ -18,6 +18,6 @@ public class MyPageService {
     public MemberInfoDTO findProfileById(Long id) {
         Member member = memberDAO.findById(id)
                 .orElseThrow(() -> new SystemException(ClientErrorCode.MEMBER_NOT_FOUND_ERR));
-        return new MemberInfoDTO(member.getPicture(), member.getNickname(), member.getProfileIntro());
+        return new MemberInfoDTO(member.getPicture(), member.getNickname(), member.getProfileIntro(), member.getEmail());
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #181 

## 📝작업 내용

사용자의 프로필을 확인할 때 이메일 값을 같이 전송할 수 있도록 추가 했습니다.

### 스크린샷 (선택)

![스크린샷 2024-09-25 오전 9 02 07](https://github.com/user-attachments/assets/cf1f071a-dcee-4524-b4fa-ebe7cedf8f0a)
