### PR TITLE
[feat/image] 원본 이미지 이름 저장해서 발송할 수 있도록 하기

### DIFF
--- a/src/main/java/chzzk/grassdiary/domain/diary/service/DiaryService.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/service/DiaryService.java
@@ -112,7 +112,7 @@ public class DiaryService {
     public List<ImageDTO> getImagesByDiary(Long diaryId) {
         return diaryToImageDAO.findByDiaryId(diaryId)
                 .stream()
-                .map(image -> ImageDTO.from(image, imageService.getImageURLByImage(image.getImage())))
+                .map(image -> ImageDTO.from(image, imageService.getImageURLByImage(image.getImage()), image.getImage().getImageName()))
                 .toList();
     }
 

--- a/src/main/java/chzzk/grassdiary/domain/image/dto/ImageDTO.java
+++ b/src/main/java/chzzk/grassdiary/domain/image/dto/ImageDTO.java
@@ -6,9 +6,10 @@ import chzzk.grassdiary.domain.image.entity.DiaryToImage;
 
 public record ImageDTO (
         Long imageId,
-        String imageURL
+        String imageURL,
+        String imageName
 ) {
-    public static ImageDTO from(DiaryToImage diaryToImage, String imageURL) {
-        return new ImageDTO(diaryToImage.getImage().getId(), imageURL);
+    public static ImageDTO from(DiaryToImage diaryToImage, String imageURL, String imageName) {
+        return new ImageDTO(diaryToImage.getImage().getId(), imageURL, imageName);
     }
 }

--- a/src/main/java/chzzk/grassdiary/domain/image/entity/Image.java
+++ b/src/main/java/chzzk/grassdiary/domain/image/entity/Image.java
@@ -22,7 +22,10 @@ public class Image extends BaseCreatedTimeEntity {
     @Lob
     private String imagePath;
 
-    public Image(String imagePath) {
+    private String imageName;
+
+    public Image(String imagePath, String imageName) {
         this.imagePath = imagePath;
+        this.imageName = imageName;
     }
 }

--- a/src/main/java/chzzk/grassdiary/domain/image/service/ImageService.java
+++ b/src/main/java/chzzk/grassdiary/domain/image/service/ImageService.java
@@ -31,9 +31,9 @@ public class ImageService {
             throw new SystemException(ClientErrorCode.IMAGE_FILE_EMPTY);
         }
         String imagePath = awsS3Service.uploadBucket(image, category);
-        Image uploadedImage = imageDAO.save(new Image(imagePath));
+        Image uploadedImage = imageDAO.save(new Image(imagePath, image.getOriginalFilename()));
 
-        return new ImageDTO(uploadedImage.getId(), baseURL + imagePath);
+        return new ImageDTO(uploadedImage.getId(), baseURL + imagePath, image.getOriginalFilename());
     }
 
     /**

--- a/src/main/java/chzzk/grassdiary/domain/member/dto/MemberInfoDTO.java
+++ b/src/main/java/chzzk/grassdiary/domain/member/dto/MemberInfoDTO.java
@@ -3,6 +3,7 @@ package chzzk.grassdiary.domain.member.dto;
 public record MemberInfoDTO(
         String profileImageURL,
         String nickname,
-        String profileIntro
+        String profileIntro,
+        String email
 ) {
 }

--- a/src/main/java/chzzk/grassdiary/domain/member/service/MyPageService.java
+++ b/src/main/java/chzzk/grassdiary/domain/member/service/MyPageService.java
@@ -18,6 +18,6 @@ public class MyPageService {
     public MemberInfoDTO findProfileById(Long id) {
         Member member = memberDAO.findById(id)
                 .orElseThrow(() -> new SystemException(ClientErrorCode.MEMBER_NOT_FOUND_ERR));
-        return new MemberInfoDTO(member.getPicture(), member.getNickname(), member.getProfileIntro());
+        return new MemberInfoDTO(member.getPicture(), member.getNickname(), member.getProfileIntro(), member.getEmail());
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #180 

## 📝작업 내용

이미지 원본 이름이 필요하여 저장할 수 있도록 수정하였습니다.

### 스크린샷 (선택)

![스크린샷 2024-09-25 오전 10 10 44](https://github.com/user-attachments/assets/debe2b92-4a34-4530-830d-350f05585103)

`image`의 `imageName`이 추가 되었습니다.