### PR TITLE
fix (delete-account) : withdrawn member의 nickname을 null로 변경되도록 수정

### DIFF
--- a/src/main/java/chzzk/grassdiary/domain/member/entity/Member.java
+++ b/src/main/java/chzzk/grassdiary/domain/member/entity/Member.java
@@ -99,7 +99,7 @@ public class Member extends BaseTimeEntity {
 
     public void withdrawMember() {
         this.rewardPoint = 0;
-        this.nickname = "탈퇴한 회원";
+        this.nickname = null;
         this.email = "withdrawnMember";
         this.profileIntro = null;
         this.picture = null;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #198

## 📝작업 내용

> 닉네임 중복이 막혀있어서 withdrawn member의 nickname을 null로 변경되도록 수정했습니다.

