### PR TITLE
feat(diary): 날짜와 상관없이 다이어리 공개 범위 수정하는 api 추가

### DIFF
--- a/src/main/java/chzzk/grassdiary/domain/diary/controller/DiaryController.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/controller/DiaryController.java
@@ -41,6 +41,14 @@ public class DiaryController {
         return diaryService.update(diaryId, requestDto);
     }
 
+    @PatchMapping("/{diaryId}/visibility")
+    public ResponseEntity<?> updateVisibility(
+            @PathVariable(name = "diaryId") Long diaryId,
+            @AuthenticatedMember AuthMemberPayload loginMember) {
+        diaryService.updateVisibility(diaryId, loginMember.id());
+        return ResponseEntity.noContent().build();
+    }
+
     @DeleteMapping("/{diaryId}")
     public Long delete(@PathVariable(name = "diaryId") Long diaryId,
                        @AuthenticatedMember AuthMemberPayload payload) {

--- a/src/main/java/chzzk/grassdiary/domain/diary/entity/Diary.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/entity/Diary.java
@@ -79,6 +79,10 @@ public class Diary extends BaseTimeEntity {
         this.conditionLevel = conditionLevel;
     }
 
+    public void updateVisibility() {
+        this.isPrivate = !this.isPrivate;
+    }
+
     public LocalDateTime getCreatedAt() {
         return super.getCreatedAt();
     }

--- a/src/main/java/chzzk/grassdiary/domain/diary/service/DiaryService.java
+++ b/src/main/java/chzzk/grassdiary/domain/diary/service/DiaryService.java
@@ -83,6 +83,14 @@ public class DiaryService {
         return updateDiary(requestDto, originalDiary);
     }
 
+    @Transactional
+    public void updateVisibility(Long diaryId, Long loginMemberId) {
+        Diary diary = getDiaryById(diaryId);
+
+        validateDiaryOwner(diary, loginMemberId);
+        diary.updateVisibility();
+    }
+
     /**
      * diaryId를 이용해서 diaryTag, MemberTag 를 찾아내기 diaryTag 삭제 -> deleteAllInBatch 고려해보기 MemberTag 삭제 해당 일기의 좋아요 찾기 및 삭제
      * 이미지 삭제


### PR DESCRIPTION
## #️⃣연관된 이슈

> X

## 📝작업 내용

다이어리 작성일과 상관 없이 수정 가능하도록 새로운 API를 만들었습니다.
PATH `/api/diary/{diaryID}/visibility`
